### PR TITLE
Support NODATA and SKIPDATA entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,7 +106,7 @@ ClientBin
 stylecop.*
 ~$*
 *.dbmdl
-Generated_Code #added for RIA/Silverlight projects
+Generated_Code
 
 # Backup & report files from converting an old project file to a newer
 # Visual Studio version. Backup files are not needed, because we have git ;-)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: python
+
+python:
+    - "2.7"
+    - "3.2"
+    - "3.3"
+    - "3.4"
+
+install:
+    - pip install --upgrade setuptools
+    - python setup.py develop
+
+script:
+    - python setup.py test

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -19,6 +19,11 @@ from datetime import datetime, timedelta
 
 import boto3
 
+ACCEPT = 'ACCEPT'
+REJECT = 'REJECT'
+SKIPDATA = 'SKIPDATA'
+NODATA = 'NODATA'
+
 
 class FlowRecord(object):
     """

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -53,17 +53,28 @@ class FlowRecord(object):
         self.version = int(fields[0])
         self.account_id = fields[1]
         self.interface_id = fields[2]
-        self.srcaddr = fields[3]
-        self.dstaddr = fields[4]
-        self.srcport = int(fields[5])
-        self.dstport = int(fields[6])
-        self.protocol = int(fields[7])
-        self.packets = int(fields[8])
-        self.bytes = int(fields[9])
         self.start = datetime.utcfromtimestamp(int(fields[10]))
         self.end = datetime.utcfromtimestamp(int(fields[11]))
-        self.action = fields[12]
+
         self.log_status = fields[13]
+        if self.log_status in (NODATA, SKIPDATA):
+            self.srcaddr = None
+            self.dstaddr = None
+            self.srcport = None
+            self.dstport = None
+            self.protocol = None
+            self.packets = None
+            self.bytes = None
+            self.action = None
+        else:
+            self.srcaddr = fields[3]
+            self.dstaddr = fields[4]
+            self.srcport = int(fields[5])
+            self.dstport = int(fields[6])
+            self.protocol = int(fields[7])
+            self.packets = int(fields[8])
+            self.bytes = int(fields[9])
+            self.action = fields[12]
 
     def __eq__(self, other):
         return all(
@@ -88,7 +99,7 @@ class FlowRecord(object):
 
         ret = []
         for attr in self.__slots__:
-            transform = D_transform.get(attr, lambda x: str(x))
+            transform = D_transform.get(attr, lambda x: str(x) if x else '-')
             ret.append(transform(getattr(self, attr)))
 
         return ' '.join(ret)

--- a/tests/test_flowlogs_reader.py
+++ b/tests/test_flowlogs_reader.py
@@ -36,6 +36,14 @@ SAMPLE_RECORDS = [
         '2 123456789010 eni-102010ab 192.0.2.1 198.51.100.1 '
         '49152 443 6 20 1680 1439387265 1439387266 REJECT OK'
     ),
+    (
+        '2 123456789010 eni-1a2b3c4d - - - - - - - '
+        '1431280876 1431280934 - NODATA'
+    ),
+    (
+        '2 123456789010 eni-4b118871 - - - - - - - '
+        '1431280876 1431280934 - SKIPDATA'
+    ),
 ]
 
 
@@ -222,10 +230,14 @@ class FlowLogReaderTestCase(TestCase):
     def test_iteration(self, mock_get, mock_filter, mock_read):
         def mock_read_stream(self, stream_name):
             D = {
-                'stream_0': [{'message': SAMPLE_RECORDS[0]}],
-                'stream_1': [
+                'stream_0': [
+                    {'message': SAMPLE_RECORDS[0]},
                     {'message': SAMPLE_RECORDS[1]},
+                ],
+                'stream_1': [
                     {'message': SAMPLE_RECORDS[2]},
+                    {'message': SAMPLE_RECORDS[3]},
+                    {'message': SAMPLE_RECORDS[4]},
                 ],
             }
             return D[stream_name]


### PR DESCRIPTION
According to the [VPC Flow Logs](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/flow-logs.html) documentation, there are two cases in which they may not provide data. This adds support to handle those gracefully (instead of throwing a `ValueError` as would currently happen).