### PR TITLE
Command line interface

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,10 @@
+[report]
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    if self.debug:
+    if settings.DEBUG
+    raise AssertionError
+    raise NotImplementedError
+    if 0:
+    if __name__ == .__main__.:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,21 @@ For information on VPC Flow Logs and how to enable them see [this post](https://
 
 __Note__: The library is still experimental. Give it a try and file an issue or pull request if you have suggestions.
 
-## Usage
+## CLI Usage
+
+`flowlogs-reader` provides a command line interface called `flowlogs_reader` that allows you to print VPC Flow Log records to your screen. It assumes your AWS credentials are available through environment variables, a boto configuration file, or through IAM metadata. Some example uses are:
+
+* `flowlogs_reader flowlog_group` - print all flows in the past hour
+* `flowlogs_reader -s '2015-08-13 00:00:00' -e '2015-08-14 00:00:00' flowlog_group` - print all the flows from August 13, 2015
+* `flowlogs_reader flowlog_group ipset` - print the unique IPs seen in the past hour
+* `flowlogs_reader flowlog_group findip 198.51.100.2` - print all flows involving 198.51.100.2
+
+Or combine with other command line utilities:
+
+* `flowlogs_reader flowlog_group | grep REJECT` - print all `REJECT`ed Flow Log records
+* `flowlogs_reader flowlog_group | awk '$6 = 443` - print all traffic from port 443
+
+## Module Usage
 
 `FlowLogRecord` takes an `event` dictionary retrieved from a log stream. It parses the `message` in the event, which takes a record like this:
 

--- a/flowlogs_reader/__main__.py
+++ b/flowlogs_reader/__main__.py
@@ -18,7 +18,7 @@ import sys
 from argparse import ArgumentParser
 from datetime import datetime
 
-from .flowlogs_reader import FlowLogReader
+from .flowlogs_reader import FlowLogReader, SKIPDATA, NODATA
 
 actions = {}
 
@@ -34,6 +34,8 @@ def action_ipset(reader, *args):
     """Show the set of IPs seen in Flow Log records."""
     ip_set = set()
     for record in reader:
+        if record.log_status in (SKIPDATA, NODATA):
+            continue
         ip_set.add(record.srcaddr)
         ip_set.add(record.dstaddr)
 
@@ -66,7 +68,8 @@ def get_reader(args):
     return FlowLogReader(log_group_name=args.logGroupName, **kwargs)
 
 
-def main():
+def main(argv=None):
+    argv = argv or sys.argv[1:]
     parser = ArgumentParser(description='Read records from VPC Flow Logs')
     parser.add_argument('logGroupName', type=str,
                         help='name of flow log group to read')
@@ -80,7 +83,7 @@ def main():
                         help='filter stream records before this time')
     parser.add_argument('--time-format', type=str, default='%Y-%m-%d %H:%M:%S',
                         help='format of time to parse')
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     action = args.action[0]
     try:

--- a/flowlogs_reader/__main__.py
+++ b/flowlogs_reader/__main__.py
@@ -1,0 +1,97 @@
+#  Copyright 2015 Observable Networks
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import sys
+from argparse import ArgumentParser
+from datetime import datetime
+
+from .flowlogs_reader import FlowLogReader
+
+actions = {}
+
+
+def action_print(reader, *args):
+    """Simply print the Flow Log records to output."""
+    for record in reader:
+        print(record.to_message())
+actions['print'] = action_print
+
+
+def action_ipset(reader, *args):
+    """Show the set of IPs seen in Flow Log records."""
+    ip_set = set()
+    for record in reader:
+        ip_set.add(record.srcaddr)
+        ip_set.add(record.dstaddr)
+
+    for ip in ip_set:
+        print(ip)
+actions['ipset'] = action_ipset
+
+
+def action_findip(reader, *args):
+    """Find Flow Log records involving a specific IP or IPs."""
+    target_ips = set(args)
+    for record in reader:
+        if (record.srcaddr in target_ips) or (record.dstaddr in target_ips):
+            print(record.to_message())
+actions['findip'] = action_findip
+
+
+def get_reader(args):
+    kwargs = {
+        'region_name': args.region,
+    }
+    time_format = args.time_format
+
+    if args.start_time:
+        kwargs['start_time'] = datetime.strptime(args.start_time, time_format)
+
+    if args.end_time:
+        kwargs['end_time'] = datetime.strptime(args.end_time, time_format)
+
+    return FlowLogReader(log_group_name=args.logGroupName, **kwargs)
+
+
+def main():
+    parser = ArgumentParser(description='Read records from VPC Flow Logs')
+    parser.add_argument('logGroupName', type=str,
+                        help='name of flow log group to read')
+    parser.add_argument('action', type=str, nargs='*', default=['print'],
+                        help='action to take on log records')
+    parser.add_argument('--region', type=str, default='us-east-1',
+                        help='AWS region the Log Group is in')
+    parser.add_argument('--start-time', '-s', type=str,
+                        help='filter stream records at or after this time')
+    parser.add_argument('--end-time', '-e', type=str,
+                        help='filter stream records before this time')
+    parser.add_argument('--time-format', type=str, default='%Y-%m-%d %H:%M:%S',
+                        help='format of time to parse')
+    args = parser.parse_args()
+
+    action = args.action[0]
+    try:
+        action_method = actions[action]
+    except KeyError:
+        print('unknown action: {}'.format(action), file=sys.stderr)
+        print('known actions: {}'.format(', '.join(actions)), file=sys.stderr)
+    else:
+        reader = get_reader(args)
+        action_method(reader, *args.action[1:])
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 from setuptools import setup, find_packages
+
+PY3 = (sys.version_info >= (3,))
 
 setup(
     name='flowlogs_reader',
@@ -49,5 +52,5 @@ setup(
     test_suite='tests',
 
     install_requires=['botocore', 'boto3'],
-    tests_require=['mock'],
+    tests_require=['mock'] if PY3 else [],
 )

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,11 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
     ],
+    entry_points={
+        'console_scripts': [
+            'flowlogs_reader = flowlogs_reader.__main__:main',
+        ],
+    },
 
     packages=find_packages(exclude=[]),
     test_suite='tests',

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,8 @@ setup(
 
     classifiers=[
         'Intended Audience :: Developers',
+        'Intended Audience :: Information Technology',
+        'Intended Audience :: System Administrators',
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',

--- a/tests/test_flowlogs_reader.py
+++ b/tests/test_flowlogs_reader.py
@@ -18,7 +18,10 @@ from calendar import timegm
 from datetime import datetime, timedelta
 from unittest import TestCase
 
-from mock import MagicMock, patch
+try:
+    from unittest.mock import MagicMock, patch
+except ImportError:
+    from mock import MagicMock, patch
 
 from flowlogs_reader import FlowRecord, FlowLogReader
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -53,17 +53,19 @@ SAMPLE_RECORDS = [FlowRecord.from_message(m) for m in SAMPLE_INPUT]
 class MainTestCase(TestCase):
     def test_main(self, mock_reader):
         main(['mygroup'])
-        mock_reader.assert_called_with('mygroup', region_name='us-east-1')
+        mock_reader.assert_called_with(
+            log_group_name='mygroup', region_name='us-east-1'
+        )
 
         main(['-s', '2015-05-05 14:20:00', 'mygroup'])
         mock_reader.assert_called_with(
-            'mygroup', region_name='us-east-1',
+            log_group_name='mygroup', region_name='us-east-1',
             start_time=datetime(2015, 5, 5, 14, 20)
         )
 
         main(['--end-time', '2015-05-05 14:20:00', 'mygroup'])
         mock_reader.assert_called_with(
-            'mygroup', region_name='us-east-1',
+            log_group_name='mygroup', region_name='us-east-1',
             end_time=datetime(2015, 5, 5, 14, 20)
         )
 
@@ -73,12 +75,13 @@ class MainTestCase(TestCase):
             'mygroup'
         ])
         mock_reader.assert_called_with(
-            'mygroup', region_name='us-east-1', start_time=datetime(2015, 5, 5)
+            log_group_name='mygroup', region_name='us-east-1',
+            start_time=datetime(2015, 5, 5)
         )
 
         main(['--region', 'us-west-1', 'mygroup'])
         mock_reader.assert_called_with(
-            'mygroup', region_name='us-west-1'
+            log_group_name='mygroup', region_name='us-west-1'
         )
 
     @patch('flowlogs_reader.__main__.print', create=True)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -18,7 +18,10 @@ import io
 from datetime import datetime
 from unittest import TestCase
 
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from flowlogs_reader import FlowRecord
 from flowlogs_reader.__main__ import main, actions
@@ -49,8 +52,8 @@ SAMPLE_INPUT = [
 SAMPLE_RECORDS = [FlowRecord.from_message(m) for m in SAMPLE_INPUT]
 
 
-@patch('flowlogs_reader.__main__.FlowLogReader', autospec=True)
 class MainTestCase(TestCase):
+    @patch('flowlogs_reader.__main__.FlowLogReader', autospec=True)
     def test_main(self, mock_reader):
         main(['mygroup'])
         mock_reader.assert_called_with(
@@ -84,6 +87,7 @@ class MainTestCase(TestCase):
             log_group_name='mygroup', region_name='us-west-1'
         )
 
+    @patch('flowlogs_reader.__main__.FlowLogReader', autospec=True)
     @patch('flowlogs_reader.__main__.print', create=True)
     def test_main_print(self, mock_out, mock_reader):
         mock_out.stdout = io.BytesIO()
@@ -94,6 +98,7 @@ class MainTestCase(TestCase):
             line = args[0]
             self.assertEqual(line, record)
 
+    @patch('flowlogs_reader.__main__.FlowLogReader', autospec=True)
     @patch('flowlogs_reader.__main__.print', create=True)
     def test_main_ipset(self, mock_out, mock_reader):
         mock_out.stdout = io.BytesIO()
@@ -117,6 +122,7 @@ class MainTestCase(TestCase):
             actual_set.add(line)
         self.assertEqual(actual_set, expected_set)
 
+    @patch('flowlogs_reader.__main__.FlowLogReader', autospec=True)
     @patch('flowlogs_reader.__main__.print', create=True)
     def test_main_findip(self, mock_out, mock_reader):
         mock_out.stdout = io.BytesIO()
@@ -129,6 +135,7 @@ class MainTestCase(TestCase):
             line = args[0]
             self.assertEqual(line, record)
 
+    @patch('flowlogs_reader.__main__.FlowLogReader', autospec=True)
     @patch('flowlogs_reader.__main__.print', create=True)
     def test_main_bad_action(self, mock_out, mock_reader):
         mock_out.stdout = io.BytesIO()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,142 @@
+#  Copyright 2015 Observable Networks
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import io
+from datetime import datetime
+from unittest import TestCase
+
+from mock import patch
+
+from flowlogs_reader import FlowRecord
+from flowlogs_reader.__main__ import main, actions
+
+
+SAMPLE_INPUT = [
+    (
+        '2 123456789010 eni-102010ab 198.51.100.1 192.0.2.1 '
+        '443 49152 6 10 840 1439387263 1439387264 ACCEPT OK'
+    ),
+    (
+        '2 123456789010 eni-102010ab 192.0.2.1 198.51.100.1 '
+        '49152 443 6 20 1680 1439387264 1439387265 ACCEPT OK'
+    ),
+    (
+        '2 123456789010 eni-102010ab 192.0.2.1 198.51.100.2 '
+        '49152 443 6 20 1680 1439387265 1439387266 REJECT OK'
+    ),
+    (
+        '2 123456789010 eni-1a2b3c4d - - - - - - - '
+        '1431280876 1431280934 - NODATA'
+    ),
+    (
+        '2 123456789010 eni-4b118871 - - - - - - - '
+        '1431280876 1431280934 - SKIPDATA'
+    ),
+]
+SAMPLE_RECORDS = [FlowRecord.from_message(m) for m in SAMPLE_INPUT]
+
+
+@patch('flowlogs_reader.__main__.FlowLogReader', autospec=True)
+class MainTestCase(TestCase):
+    def test_main(self, mock_reader):
+        main(['mygroup'])
+        mock_reader.assert_called_with('mygroup', region_name='us-east-1')
+
+        main(['-s', '2015-05-05 14:20:00', 'mygroup'])
+        mock_reader.assert_called_with(
+            'mygroup', region_name='us-east-1',
+            start_time=datetime(2015, 5, 5, 14, 20)
+        )
+
+        main(['--end-time', '2015-05-05 14:20:00', 'mygroup'])
+        mock_reader.assert_called_with(
+            'mygroup', region_name='us-east-1',
+            end_time=datetime(2015, 5, 5, 14, 20)
+        )
+
+        main([
+            '--time-format', '%Y-%m-%d',
+            '--start-time', '2015-05-05',
+            'mygroup'
+        ])
+        mock_reader.assert_called_with(
+            'mygroup', region_name='us-east-1', start_time=datetime(2015, 5, 5)
+        )
+
+        main(['--region', 'us-west-1', 'mygroup'])
+        mock_reader.assert_called_with(
+            'mygroup', region_name='us-west-1'
+        )
+
+    @patch('flowlogs_reader.__main__.print', create=True)
+    def test_main_print(self, mock_out, mock_reader):
+        mock_out.stdout = io.BytesIO()
+        mock_reader.return_value = SAMPLE_RECORDS
+        main(['mygroup'])
+        for call, record in zip(mock_out.mock_calls, SAMPLE_INPUT):
+            __, args, kwargs = call
+            line = args[0]
+            self.assertEqual(line, record)
+
+    @patch('flowlogs_reader.__main__.print', create=True)
+    def test_main_ipset(self, mock_out, mock_reader):
+        mock_out.stdout = io.BytesIO()
+        mock_reader.return_value = SAMPLE_RECORDS
+        main(['mygroup', 'ipset'])
+
+        expected_set = set()
+        for record in SAMPLE_INPUT:
+            data = record.split()
+            expected_set.add(data[3])
+            expected_set.add(data[4])
+        # don't include SKIPDATA/NODATA in results
+        expected_set.remove('-')
+
+        # make sure the number of lines are the same as the size of the set
+        self.assertEqual(len(mock_out.mock_calls), len(expected_set))
+
+        actual_set = set()
+        for __, args, kwargs in mock_out.mock_calls:
+            line = args[0]
+            actual_set.add(line)
+        self.assertEqual(actual_set, expected_set)
+
+    @patch('flowlogs_reader.__main__.print', create=True)
+    def test_main_findip(self, mock_out, mock_reader):
+        mock_out.stdout = io.BytesIO()
+        mock_reader.return_value = SAMPLE_RECORDS
+        main(['mygroup', 'findip', '198.51.100.2'])
+
+        expected_result = [SAMPLE_INPUT[2]]
+        for call, record in zip(mock_out.mock_calls, expected_result):
+            __, args, kwargs = call
+            line = args[0]
+            self.assertEqual(line, record)
+
+    @patch('flowlogs_reader.__main__.print', create=True)
+    def test_main_bad_action(self, mock_out, mock_reader):
+        mock_out.stdout = io.BytesIO()
+        mock_reader.return_value = SAMPLE_RECORDS
+        main(['mygroup', '__'])
+
+        expected_result = [
+            'unknown action: __',
+            'known actions: {}'.format(', '.join(actions)),
+        ]
+        for call, result in zip(mock_out.mock_calls, expected_result):
+            __, args, kwargs = call
+            line = args[0]
+            self.assertEqual(line, result)


### PR DESCRIPTION
This adds a simple CLI to the program, allowing the basic examples to be done easily. For example:

* `flowlogs_reader flowlog_group` will simple print all the flows in the past hour
* `flowlogs_reader -s '2015-08-13 00:00:00' -e '2015-08-14 00:00:00' flowlog_group` prints all the flows from August 13
* `flowlogs_reader flowlog_group ipset` will print the unique IPs seen in the past hour
* `flowlogs_reader flowlog_group findip 198.51.100.2` will print all flows involving 198.51.100.2.
* Combine with other commands like `flowlogs_reader flowlog_group | grep REJECT` to show the REJECTed flows.