### PR TITLE
Iterate backwards instead of forwards

### DIFF
--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -201,6 +201,7 @@ class FlowLogsReader(object):
             'logStreamName': stream_name,
             'startTime': self.start_ms,
             'endTime': self.end_ms,
+            'startFromHead': True,
         }
 
         while True:

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -195,7 +195,7 @@ class FlowLogsReader(object):
     def _read_stream(self, stream_name):
         # Loops through the pages of the log stream with the given
         # `stream_name`, yielding the events.
-        forward_token = None
+        backward_token = None
         kwargs = {
             'logGroupName': self.log_group_name,
             'logStreamName': stream_name,
@@ -204,17 +204,17 @@ class FlowLogsReader(object):
         }
 
         while True:
-            if forward_token:
-                kwargs['nextToken'] = forward_token
+            if backward_token:
+                kwargs['nextToken'] = backward_token
 
             response = self.logs_client.get_log_events(**kwargs)
             for event in response['events']:
                 yield event
 
-            next_forward_token = response['nextForwardToken']
-            if next_forward_token == forward_token:
+            next_backward_token = response['nextBackwardToken']
+            if next_backward_token == backward_token:
                 break
-            forward_token = next_forward_token
+            backward_token = next_backward_token
 
     def _reader(self):
         # Loops through each log stream and its events, yielding a parsed

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -195,7 +195,7 @@ class FlowLogsReader(object):
     def _read_stream(self, stream_name):
         # Loops through the pages of the log stream with the given
         # `stream_name`, yielding the events.
-        backward_token = None
+        forward_token = None
         kwargs = {
             'logGroupName': self.log_group_name,
             'logStreamName': stream_name,
@@ -204,17 +204,17 @@ class FlowLogsReader(object):
         }
 
         while True:
-            if backward_token:
-                kwargs['nextToken'] = backward_token
+            if forward_token:
+                kwargs['nextToken'] = forward_token
 
             response = self.logs_client.get_log_events(**kwargs)
             for event in response['events']:
                 yield event
 
-            next_backward_token = response['nextBackwardToken']
-            if next_backward_token == backward_token:
+            next_forward_token = response['nextForwardToken']
+            if next_forward_token == forward_token:
                 break
-            backward_token = next_backward_token
+            forward_token = next_forward_token
 
     def _reader(self):
         # Loops through each log stream and its events, yielding a parsed

--- a/tests/test_flowlogs_reader.py
+++ b/tests/test_flowlogs_reader.py
@@ -218,10 +218,10 @@ class FlowLogsReaderTestCase(TestCase):
 
     def test_read_stream(self):
         response_list = [
-            {'events': [0], 'nextForwardToken': 'token_0'},
-            {'events': [1, 2], 'nextForwardToken': 'token_1'},
-            {'events': [3, 4, 5], 'nextForwardToken': 'token_1'},
-            {'events': [6], 'nextForwardToken': 'token_2'},  # Unreachable
+            {'events': [0], 'nextBackwardToken': 'token_0'},
+            {'events': [1, 2], 'nextBackwardToken': 'token_1'},
+            {'events': [3, 4, 5], 'nextBackwardToken': 'token_1'},
+            {'events': [6], 'nextBackwardToken': 'token_2'},  # Unreachable
         ]
 
         def mock_get(*args, **kwargs):

--- a/tests/test_flowlogs_reader.py
+++ b/tests/test_flowlogs_reader.py
@@ -218,10 +218,10 @@ class FlowLogsReaderTestCase(TestCase):
 
     def test_read_stream(self):
         response_list = [
-            {'events': [0], 'nextBackwardToken': 'token_0'},
-            {'events': [1, 2], 'nextBackwardToken': 'token_1'},
-            {'events': [3, 4, 5], 'nextBackwardToken': 'token_1'},
-            {'events': [6], 'nextBackwardToken': 'token_2'},  # Unreachable
+            {'events': [0], 'nextForwardToken': 'token_0'},
+            {'events': [1, 2], 'nextForwardToken': 'token_1'},
+            {'events': [3, 4, 5], 'nextForwardToken': 'token_1'},
+            {'events': [6], 'nextForwardToken': 'token_2'},  # Unreachable
         ]
 
         def mock_get(*args, **kwargs):


### PR DESCRIPTION
Per the [AWS docs](http://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_GetLogEvents.html#CWL-GetLogEvents-request-StartFromHead) it looks like the API call returns 10,000 events starting at the most recent time not the earliest time if StartFromHead is not specified. As such, we'd want to page through the results going backwards instead of forwards.