### PR TITLE
Switch to filter_log_events

### DIFF
--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -159,7 +159,6 @@ class FlowLogsReader(object):
         return self.__next__()
 
     def _read_streams(self):
-        next_token = None
         kwargs = {
             'logGroupName': self.log_group_name,
             'startTime': self.start_ms,
@@ -173,7 +172,7 @@ class FlowLogsReader(object):
                 yield event
 
             next_token = response.get('nextToken')
-            if next_token:
+            if next_token is not None:
                 kwargs['nextToken'] = next_token
             else:
                 break

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -115,11 +115,10 @@ class FlowLogsReader(object):
     * `log_group_name` is the name of the CloudWatch Logs group that stores
     your VPC flow logs.
     * `region_name` is the AWS region.
-    * `start_time` is a Python datetime.datetime object; only log streams that
-    were ingested at or after this time will be examined, and only events at
-    or after this time will be yielded.
-    * `end_time` is similar to start time. Only log streams and events after
-    this time will be considered.
+    * `start_time` is a Python datetime.datetime object; only the log events
+    from at or after this time will be considered.
+    * `end_time` is a Python datetime.datetime object; only the log events
+    before this time will be considered.
     * boto_client_kwargs - other keyword arguments to pass to boto3.client
     """
 

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -168,15 +168,14 @@ class FlowLogsReader(object):
         }
 
         while True:
-            if next_token:
-                kwargs['nextToken'] = next_token
-
             response = self.logs_client.filter_log_events(**kwargs)
             for event in response['events']:
                 yield event
 
             next_token = response.get('nextToken')
-            if not next_token:
+            if next_token:
+                kwargs['nextToken'] = next_token
+            else:
                 break
 
     def _reader(self):


### PR DESCRIPTION
@mjschultz points out that using the `FilterLogEvents` API call would allow for simplified access to the relevant log streams. This PR makes that switch and removes the unneeded methods.

The tests get better too; there's only one `patch` now.