### PR TITLE
Attempt to use configured default AWS region 

### DIFF
--- a/tests/test_flowlogs_reader.py
+++ b/tests/test_flowlogs_reader.py
@@ -17,12 +17,16 @@ from __future__ import division, print_function
 from datetime import datetime
 from unittest import TestCase
 
+
+from botocore.exceptions import NoRegionError
+
 try:
     from unittest.mock import MagicMock, patch
 except ImportError:
     from mock import MagicMock, patch
 
 from flowlogs_reader import FlowRecord, FlowLogsReader
+from flowlogs_reader.flowlogs_reader import DEFAULT_REGION_NAME
 
 
 SAMPLE_RECORDS = [
@@ -163,7 +167,6 @@ class FlowLogsReaderTestCase(TestCase):
         )
 
     def test_init(self):
-        # __init__ sets the log group name and time stamps
         self.assertEqual(self.inst.log_group_name, 'group_name')
 
         self.assertEqual(
@@ -175,6 +178,25 @@ class FlowLogsReaderTestCase(TestCase):
             datetime.utcfromtimestamp(self.inst.end_ms // 1000),
             self.end_time
         )
+
+    @patch('flowlogs_reader.flowlogs_reader.boto3.client', autospec=True)
+    def test_region(self, mock_client):
+        # Region specified
+        FlowLogsReader('some_group', region_name='some-region')
+        mock_client.assert_called_with('logs', region_name='some-region')
+
+        # No region specified - assume configuration file worked
+        FlowLogsReader('some_group')
+        mock_client.assert_called_with('logs')
+
+        # No region specified and no configuration file
+        def mock_response(*args, **kwargs):
+            if 'region_name' not in kwargs:
+                raise NoRegionError
+
+        mock_client.side_effect = mock_response
+        FlowLogsReader('some_group')
+        mock_client.assert_called_with('logs', region_name=DEFAULT_REGION_NAME)
 
     def test_read_streams(self):
         response_list = [


### PR DESCRIPTION
Re: issue #14, this PR changes `FlowLogsReader` such that it honors the user's region configuration.

According to the [boto3 documentation](http://boto3.readthedocs.org/en/latest/guide/configuration.html), you may try to initialize `boto3.client` without a region specified if the `AWS_DEFAULT_REGION` environment variable is set or if the `~/.aws/config` file has a default region set.

`FlowLogsReader` now behaves like this:
* If you request a region, it uses that one
* If you don't request a region, it tries to use the environment or profile default
* If you don't request a region, and there's no environment or profile, it uses `us-east-1`.

@hjacobs, I presume this will fix your issue? I will merge this, create a new release, and close #14 if so.