### PR TITLE
Use filter_log_events paginator

### DIFF
--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -158,23 +158,17 @@ class FlowLogsReader(object):
         return self.__next__()
 
     def _read_streams(self):
-        kwargs = {
-            'logGroupName': self.log_group_name,
-            'startTime': self.start_ms,
-            'endTime': self.end_ms,
-            'interleaved': True,
-        }
+        paginator = self.logs_client.get_paginator('filter_log_events')
+        response_iterator = paginator.paginate(
+            logGroupName=self.log_group_name,
+            startTime=self.start_ms,
+            endTime=self.end_ms,
+            interleaved=True,
+        )
 
-        while True:
-            response = self.logs_client.filter_log_events(**kwargs)
-            for event in response['events']:
+        for page in response_iterator:
+            for event in page['events']:
                 yield event
-
-            next_token = response.get('nextToken')
-            if next_token is not None:
-                kwargs['nextToken'] = next_token
-            else:
-                break
 
     def _reader(self):
         # Loops through each log stream and its events, yielding a parsed

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,6 @@ setup(
     packages=find_packages(exclude=[]),
     test_suite='tests',
 
-    install_requires=['botocore', 'boto3'],
+    install_requires=['botocore>=1.2.0', 'boto3>=1.1.3'],
     tests_require=['mock'] if PY3 else [],
 )

--- a/tests/test_flowlogs_reader.py
+++ b/tests/test_flowlogs_reader.py
@@ -177,30 +177,25 @@ class FlowLogsReaderTestCase(TestCase):
         )
 
     def test_read_streams(self):
-        response_list = [
-            {'events': [0], 'nextToken': 'token_0'},
-            {'events': [1, 2], 'nextToken': 'token_1'},
-            {'events': [3, 4, 5], 'nextToken': None},
-            {'events': [6], 'nextForwardToken': 'token_2'},  # Unreachable
+        paginator = MagicMock()
+        paginator.paginate.return_value = [
+            {'events': [0]}, {'events': [1, 2]}, {'events': [3, 4, 5]},
         ]
 
-        def mock_filter(*args, **kwargs):
-            return response_list.pop(0)
-
-        self.mock_client.filter_log_events.side_effect = mock_filter
+        self.mock_client.get_paginator.return_value = paginator
 
         actual = list(self.inst._read_streams())
         expected = [0, 1, 2, 3, 4, 5]
         self.assertEqual(actual, expected)
 
     def test_iteration(self):
-        response_list = [
+        paginator = MagicMock()
+        paginator.paginate.return_value = [
             {
                 'events': [
                     {'logStreamName': 'log_0', 'message': SAMPLE_RECORDS[0]},
                     {'logStreamName': 'log_0', 'message': SAMPLE_RECORDS[1]},
                 ],
-                'nextToken': 'token_0',
             },
             {
                 'events': [
@@ -211,10 +206,7 @@ class FlowLogsReaderTestCase(TestCase):
             },
         ]
 
-        def mock_filter(*args, **kwargs):
-            return response_list.pop(0)
-
-        self.mock_client.filter_log_events.side_effect = mock_filter
+        self.mock_client.get_paginator.return_value = paginator
 
         # Calling list on the instance causes it to iterate through all records
         actual = list(self.inst)


### PR DESCRIPTION
Recent boto3 and botocore releases now support [pagination](http://boto3.readthedocs.org/en/latest/reference/services/logs.html#CloudWatchLogs.Paginator.filter_log_events) for CloudWatch logs. This PR:

* Updates the boto3 and botocore version recommendations (to the latest)
* Removes manual pagination and replaces it with automatic pagination