### PR TITLE
Add support for boto3 configuration profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ By default it will retrieve records from log streams that were ingested in the l
 
 You can control what's retrieved with these parameters:
 * `region_name` is a string like `'us-east-1'`
+* `profile_name` is a string like `'my-profile'`
 * `start_time` and `end_time` are Python `datetime.datetime` objects
 * `boto_client_kwargs` is a dictionary of parameters to pass to `boto3.client`
 
@@ -119,4 +120,15 @@ records = []
 for record in FlowLogsReader('flowlog_group'):
     if (record.srcaddr == target_ip) or (record.dstaddr == target_ip):
         records.append(record)
+```
+
+Loop through a few preconfigured profiles and collect all of the IP addresses:
+
+```python
+ip_set = set()
+profile_names = ['profile1', 'profile2']
+for profile_name in profile_names:
+    for record in FlowLogsReader('flowlog_group', profile_name=profile_name):
+        ip_set.add(record.srcaddr)
+        ip_set.add(record.dstaddr)
 ```

--- a/flowlogs_reader/__main__.py
+++ b/flowlogs_reader/__main__.py
@@ -55,7 +55,8 @@ actions['findip'] = action_findip
 
 def get_reader(args):
     kwargs = {
-        'region_name': args.region,
+        'region_name': args.region or None,
+        'profile_name': args.profile or None
     }
     time_format = args.time_format
 
@@ -75,7 +76,9 @@ def main(argv=None):
                         help='name of flow log group to read')
     parser.add_argument('action', type=str, nargs='*', default=['print'],
                         help='action to take on log records')
-    parser.add_argument('--region', type=str, default='us-east-1',
+    parser.add_argument('--profile', type=str, default='',
+                        help='boto3 configuration profile to use')
+    parser.add_argument('--region', type=str, default='',
                         help='AWS region the Log Group is in')
     parser.add_argument('--start-time', '-s', type=str,
                         help='filter stream records at or after this time')

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -18,10 +18,7 @@ from calendar import timegm
 from datetime import datetime, timedelta
 
 import boto3
-from botocore.exceptions import NoRegionError
 
-
-DEFAULT_REGION_NAME = 'us-east-1'
 
 ACCEPT = 'ACCEPT'
 REJECT = 'REJECT'

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -145,7 +145,8 @@ class FlowLogsReader(object):
         if region_name is not None:
             session_kwargs['region_name'] = region_name
         elif 'region_name' in boto_client_kwargs:
-            session_kwargs['region_name'] = boto_client_kwargs['region_name']
+            region_name = boto_client_kwargs.pop('region_name')
+            session_kwargs['region_name'] = region_name
 
         if profile_name is not None:
             session_kwargs['profile_name'] = profile_name

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -137,6 +137,7 @@ class FlowLogsReader(object):
         boto_client_kwargs=None
     ):
         boto_client_kwargs = boto_client_kwargs or {}
+        boto_client_kwargs = boto_client_kwargs.copy()
         session_kwargs = {}
 
         # If a region_name is specified, use that for the session

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -57,19 +57,19 @@ class MainTestCase(TestCase):
     def test_main(self, mock_reader):
         main(['mygroup'])
         mock_reader.assert_called_with(
-            log_group_name='mygroup', region_name='us-east-1'
+            log_group_name='mygroup', region_name=None, profile_name=None
         )
 
         main(['-s', '2015-05-05 14:20:00', 'mygroup'])
         mock_reader.assert_called_with(
-            log_group_name='mygroup', region_name='us-east-1',
-            start_time=datetime(2015, 5, 5, 14, 20)
+            log_group_name='mygroup', region_name=None,
+            start_time=datetime(2015, 5, 5, 14, 20), profile_name=None
         )
 
         main(['--end-time', '2015-05-05 14:20:00', 'mygroup'])
         mock_reader.assert_called_with(
-            log_group_name='mygroup', region_name='us-east-1',
-            end_time=datetime(2015, 5, 5, 14, 20)
+            log_group_name='mygroup', region_name=None,
+            end_time=datetime(2015, 5, 5, 14, 20), profile_name=None
         )
 
         main([
@@ -78,13 +78,20 @@ class MainTestCase(TestCase):
             'mygroup'
         ])
         mock_reader.assert_called_with(
-            log_group_name='mygroup', region_name='us-east-1',
-            start_time=datetime(2015, 5, 5)
+            log_group_name='mygroup', region_name=None,
+            start_time=datetime(2015, 5, 5), profile_name=None
         )
 
         main(['--region', 'us-west-1', 'mygroup'])
         mock_reader.assert_called_with(
-            log_group_name='mygroup', region_name='us-west-1'
+            log_group_name='mygroup', region_name='us-west-1',
+            profile_name=None
+        )
+
+        main(['--profile', 'my-profile', 'mygroup'])
+        mock_reader.assert_called_with(
+            log_group_name='mygroup', region_name=None,
+            profile_name='my-profile'
         )
 
     @patch('flowlogs_reader.__main__.FlowLogsReader', autospec=True)


### PR DESCRIPTION
This allows multiple boto3 configuration profiles to be used by adding a option to specify `profile_name` to FlowLogsReader.