### PR TITLE
Filter for VPC flow logs by default

### DIFF
--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -177,8 +177,9 @@ class FlowLogsReader(object):
         self.start_ms = timegm(start_time.utctimetuple()) * 1000
         self.end_ms = timegm(end_time.utctimetuple()) * 1000
 
-    def __iter__(self):
         self.iterator = self._reader()
+
+    def __iter__(self):
         return self
 
     def __next__(self):

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -21,6 +21,11 @@ import boto3
 from botocore.exceptions import NoRegionError
 
 
+DEFAULT_FILTER_PATTERN = (
+    '[version="2", account_id, interface_id, srcaddr, dstaddr, '
+    'srcport, dstport, protocol, packets, bytes, '
+    'start, end, action, log_status]'
+)
 DEFAULT_REGION_NAME = 'us-east-1'
 
 ACCEPT = 'ACCEPT'
@@ -135,7 +140,7 @@ class FlowLogsReader(object):
         profile_name=None,
         start_time=None,
         end_time=None,
-        filter_pattern=None,
+        filter_pattern=DEFAULT_FILTER_PATTERN,
         boto_client_kwargs=None
     ):
         boto_client_kwargs = boto_client_kwargs or {}

--- a/tests/test_flowlogs_reader.py
+++ b/tests/test_flowlogs_reader.py
@@ -256,6 +256,6 @@ class FlowLogsReaderTestCase(TestCase):
         self.mock_client.get_paginator.return_value = paginator
 
         # Calling list on the instance causes it to iterate through all records
-        actual = list(self.inst)
+        actual = [next(self.inst)] + list(self.inst)
         expected = [FlowRecord.from_message(x) for x in SAMPLE_RECORDS]
         self.assertEqual(actual, expected)


### PR DESCRIPTION
In [v0.5.0](https://github.com/obsrvbl/flowlogs-reader/releases/tag/v0.5.0) we added support for filter patterns. This PR changes `FlowLogsReader` objects to use a filter pattern by default. This will allow for easy querying of groups that have VPC Flow Logs and other types mixed together.

Bonus: c259c862fbb71d78690172c44ad4ee0f4994070d allows for the `FlowLogsReader` to be used with `next` after initialization.