### PR TITLE
Optionally limit number of records fetched and printed

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ python setup.py develop
 `flowlogs-reader` provides a command line interface called `flowlogs_reader` that allows you to print VPC Flow Log records to your screen. It assumes your AWS credentials are available through environment variables, a boto configuration file, or through IAM metadata. Some example uses are:
 
 * `flowlogs_reader flowlog_group` - print all flows in the past hour
+* `flowlogs_reader flowlog_group print 10` - print the first 10 flows from the past hour
 * `flowlogs_reader -s '2015-08-13 00:00:00' -e '2015-08-14 00:00:00' flowlog_group` - print all the flows from August 13, 2015
 * `flowlogs_reader flowlog_group ipset` - print the unique IPs seen in the past hour
 * `flowlogs_reader flowlog_group findip 198.51.100.2` - print all flows involving 198.51.100.2

--- a/flowlogs_reader/__main__.py
+++ b/flowlogs_reader/__main__.py
@@ -25,8 +25,18 @@ actions = {}
 
 def action_print(reader, *args):
     """Simply print the Flow Log records to output."""
-    for record in reader:
+    arg_count = len(args)
+    if arg_count == 0:
+        stop_after = 0
+    elif arg_count == 1:
+        stop_after = int(args[0])
+    else:
+        raise RuntimeError("0 or 1 arguments expected for action 'print'")
+
+    for i, record in enumerate(reader, 1):
         print(record.to_message())
+        if i == stop_after:
+            break
 actions['print'] = action_print
 
 

--- a/setup.py
+++ b/setup.py
@@ -15,11 +15,11 @@
 import sys
 from setuptools import setup, find_packages
 
-PY3 = (sys.version_info >= (3,))
+PY2 = sys.version_info[0] == 2
 
 setup(
     name='flowlogs_reader',
-    version='0.5.0',
+    version='0.6.0',
     license='Apache',
     url='https://github.com/obsrvbl/flowlogs-reader',
 
@@ -53,5 +53,5 @@ setup(
     test_suite='tests',
 
     install_requires=['botocore>=1.2.0', 'boto3>=1.1.3'],
-    tests_require=['mock'] if PY3 else [],
+    tests_require=['mock'] if PY2 else [],
 )


### PR DESCRIPTION
Adds an option to the CLI tool to limit the number of records fetched and printed (useful if you specify `--start-time` and not `--end-time`).

Also, seems we were installing the `mock` module for tests on Python 3 instead of Python 2. That's fixed here.

I'll release this revision to PyPI.