### PR TITLE
Allow users to pass in boto3 client

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,11 +97,12 @@ You may use the `FlowRecord.from_message(...)` constructor if you have a line of
 By default it will retrieve records from log streams that were ingested in the last hour, and yield records from those log streams in that same time window.
 
 You can control what's retrieved with these parameters:
-* `region_name` is a string like `'us-east-1'`
-* `profile_name` is a string like `'my-profile'`
 * `start_time` and `end_time` are Python `datetime.datetime` objects
 * `filter_pattern` is a string like `REJECT` or `443` used to filter the logs. See the examples below.
-* `boto_client_kwargs` is a dictionary of parameters to pass to `boto3.client`
+* `region_name` is a string like `'us-east-1'`. This will be used to create a [boto3 Session object](http://boto3.readthedocs.io/en/latest/reference/core/session.html#boto3.session.Session).
+* `profile_name` is a string like `'my-profile'`
+* `boto_client_kwargs` is a dictionary of parameters to pass when creating the [boto3 client](http://boto3.readthedocs.io/en/latest/reference/core/session.html#boto3.session.Session.client).
+* `boto_client` is a boto3 client object. This takes overrides `region_name`, `profile_name`, and `boto_client_kwargs`.
 
 ## Examples
 

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -130,7 +130,9 @@ class FlowLogsReader(object):
     * `end_time` is a Python datetime.datetime object; only the log events
     before this time will be considered.
     * `filter_pattern` is a string passed to CloudWatch as a filter pattern
-    * boto_client_kwargs - other keyword arguments to pass to boto3.client
+    * `boto_client_kwargs` - keyword arguments to pass to the boto3 client
+    * `boto_client` - your own boto3 client object. If given then region_name,
+    profile_name, and boto_client_kwargs will be ignored.
     """
 
     def __init__(
@@ -178,17 +180,14 @@ class FlowLogsReader(object):
         return self.__next__()
 
     def _get_client(self, region_name, profile_name, boto_client_kwargs):
-        if boto_client_kwargs is not None:
-            client_kwargs = boto_client_kwargs.copy()
-        else:
-            client_kwargs = {}
-
         session_kwargs = {}
         if region_name is not None:
             session_kwargs['region_name'] = region_name
 
         if profile_name is not None:
             session_kwargs['profile_name'] = profile_name
+
+        client_kwargs = boto_client_kwargs or {}
 
         session = boto3.session.Session(**session_kwargs)
         try:


### PR DESCRIPTION
This PR makes two changes:
* Allows users to just specify their own boto3 client, in case they need to do something with [`boto3.Session`](http://boto3.readthedocs.io/en/latest/reference/core/session.html#boto3.session.Session) that we don't support.
* Makes the `boto_client_kwargs` parameter only affect the client creation, not the `Session` configuration.

@mjschultz, any objections?