### PR TITLE
Allow assume-role in CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ __Time windows__
 
 The default time window is the last hour. You may also specify a `--start-time` and/or an `--end-time`. The `-s` and `-e` switches may be used also:
 
-* `flowlogs_reader --start-time='2015-08-13 00:00:00 flowlog_group'`
+* `flowlogs_reader --start-time='2015-08-13 00:00:00' flowlog_group`
 * `flowlogs_reader --end-time='2015-08-14 00:00:00' flowlog_group`
 * `flowlogs_reader --start-time='2015-08-13 01:00:00' --end-time='2015-08-14 02:00:00' flowlog_group`
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ The default time window is the last hour. You may also specify a `--start-time` 
 * `flowlogs_reader --end-time='2015-08-14 00:00:00' flowlog_group`
 * `flowlogs_reader --start-time='2015-08-13 01:00:00' --end-time='2015-08-14 02:00:00' flowlog_group`
 
+Use the `--time-format` switch to control how start and end times are interpreted. The default is `'%Y-%m-%d %H:%M:%S'`. See the Python documentation for `strptime` for information on format strings.
+
 __AWS options__
 
 Other command line switches:

--- a/README.md
+++ b/README.md
@@ -35,18 +35,38 @@ python setup.py develop
 
 ## CLI Usage
 
-`flowlogs-reader` provides a command line interface called `flowlogs_reader` that allows you to print VPC Flow Log records to your screen. It assumes your AWS credentials are available through environment variables, a boto configuration file, or through IAM metadata. Some example uses are:
+`flowlogs-reader` provides a command line interface called `flowlogs_reader` that allows you to print VPC Flow Log records to your screen. It assumes your AWS credentials are available through environment variables, a boto configuration file, or through IAM metadata. Some example uses are below.
+
+__Printing flows__
+
+The default action is to `print` flows. You may also specify the `ipset` and `findip` actions:
 
 * `flowlogs_reader flowlog_group` - print all flows in the past hour
 * `flowlogs_reader flowlog_group print 10` - print the first 10 flows from the past hour
-* `flowlogs_reader -s '2015-08-13 00:00:00' -e '2015-08-14 00:00:00' flowlog_group` - print all the flows from August 13, 2015
 * `flowlogs_reader flowlog_group ipset` - print the unique IPs seen in the past hour
 * `flowlogs_reader flowlog_group findip 198.51.100.2` - print all flows involving 198.51.100.2
 
-Or combine with other command line utilities:
+You may combine the output of `flowlogs_reader` with other command line utilities:
 
 * `flowlogs_reader flowlog_group | grep REJECT` - print all `REJECT`ed Flow Log records
 * `flowlogs_reader flowlog_group | awk '$6 = 443'` - print all traffic from port 443
+
+__Time windows__
+
+The default time window is the last hour. You may also specify a `--start-time` and/or an `--end-time`. The `-s` and `-e` switches may be used also:
+
+* `flowlogs_reader --start-time='2015-08-13 00:00:00 flowlog_group'`
+* `flowlogs_reader --end-time='2015-08-14 00:00:00' flowlog_group`
+* `flowlogs_reader --start-time='2015-08-13 01:00:00' --end-time='2015-08-14 02:00:00' flowlog_group`
+
+__AWS options__
+
+Other command line switches:
+
+* `flowlogs_reader --region='us-west-2' flowlog_group` - connect to the given AWS region
+* `flowlogs_reader --profile='dev_profile' flowlog_group` - use the profile from your [local AWS configuration file](http://docs.aws.amazon.com/cli/latest/topic/config-vars.html) to specify credentials and regions
+* `flowlogs_reader --filter-pattern='REJECT' flowlog_group` - use the given [filter pattern](http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/FilterAndPatternSyntax.html) to have the server limit the output
+* `flowlogs_reader --role-arn='arn:aws:iam::12345678901:role/myrole' --external-id='0a1b2c3d' flowlog_group` - use the given role and external ID to connect to a 3rd party's account using [`sts assume-role`](http://docs.aws.amazon.com/cli/latest/reference/sts/assume-role.html)
 
 ## Module Usage
 


### PR DESCRIPTION
For users with access to multiple accounts via [sts assume-role](http://docs.aws.amazon.com/cli/latest/reference/sts/assume-role.html) it takes several steps to get temporary access credentials in order to view flow logs.

This PR automates that process by introducing `--role-arn` and `--external-id` command line arguments. These match the AWS CLI arguments.

`--external-id` doesn't make sense without `--role-arn`; I check for that and print an error. Using those with `--profile` may be a little strange, but I didn't forbid it.