### PR TITLE
Aggregate flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,13 @@ python setup.py develop
 
 __Printing flows__
 
-The default action is to `print` flows. You may also specify the `ipset` and `findip` actions:
+The default action is to `print` flows. You may also specify the `ipset`, `findip`, and `aggregate` actions:
 
 * `flowlogs_reader flowlog_group` - print all flows in the past hour
 * `flowlogs_reader flowlog_group print 10` - print the first 10 flows from the past hour
 * `flowlogs_reader flowlog_group ipset` - print the unique IPs seen in the past hour
 * `flowlogs_reader flowlog_group findip 198.51.100.2` - print all flows involving 198.51.100.2
+* `flowlogs_reader flowlog_group findip aggregate` - aggregate the flows by 5-tuple, then print them as a tab-separated stream (with a header)
 
 You may combine the output of `flowlogs_reader` with other command line utilities:
 
@@ -161,9 +162,6 @@ for profile_name in profile_names:
 Apply a filter for UDP traffic that was logged normally.
 
 ```python
-from flowlogs_reader import FlowLogsReader
-
-
 FILTER_PATTERN = (
     '[version="2", account_id, interface_id, srcaddr, dstaddr, '
     'srcport, dstport, protocol="17", packets, bytes, '
@@ -173,4 +171,16 @@ FILTER_PATTERN = (
 flow_log_reader = FlowLogsReader('flowlog_group', filter_pattern=FILTER_PATTERN)
 records = list(flow_log_reader)
 print(len(records))
+```
+
+You may aggregate records with the `aggregate_records` function.
+Pass in a `FlowLogsReader` object and optionally a `key_fields` tuple.
+Python `dict` objects will be yielded representing the aggregated flow records.
+By default the typical `('srcaddr', 'dstaddr', 'srcport', 'dstport', 'protocol')` will be used.
+The `start`, `end`, `packets`, and `bytes` items will be aggregated.
+
+```python
+flow_log_reader = FlowLogsReader('flowlog_group')
+key_fields = ('srcaddr', 'dstaddr')
+records = list(aggregated_records(flow_log_reader, key_fields=key_fields))
 ```

--- a/flowlogs_reader/__init__.py
+++ b/flowlogs_reader/__init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from .aggregation import aggregated_records  # noqa
 from .flowlogs_reader import FlowRecord, FlowLogsReader  # noqa
 
-__all__ = ['FlowRecord', 'FlowLogsReader']
+__all__ = ['aggregated_records', 'FlowRecord', 'FlowLogsReader']

--- a/flowlogs_reader/aggregation.py
+++ b/flowlogs_reader/aggregation.py
@@ -1,0 +1,67 @@
+#  Copyright 2015 Observable Networks
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+from collections import defaultdict
+from datetime import datetime
+
+KEY_FIELDS = ('srcaddr', 'dstaddr', 'srcport', 'dstport', 'protocol')
+
+
+class _FlowStats(object):
+    """
+    An aggregator for flow records. Sums bytes and packets and keeps track of
+    the active time window.
+    """
+    __slots__ = ['packets', 'bytes', 'start', 'end']
+
+    def __init__(self):
+        self.start = datetime.max
+        self.end = datetime.min
+        self.packets = 0
+        self.bytes = 0
+
+    def update(self, flow_record):
+        if flow_record.start < self.start:
+            self.start = flow_record.start
+        if flow_record.end > self.end:
+            self.end = flow_record.end
+        if flow_record.packets:
+            self.packets += flow_record.packets
+        if flow_record.bytes:
+            self.bytes += flow_record.bytes
+
+    def to_dict(self):
+        return {x: getattr(self, x) for x in self.__slots__}
+
+
+def aggregated_records(all_records, key_fields=KEY_FIELDS):
+    """
+    Yield dicts that correspond to aggregates of the flow records given by
+    the sequence of FlowRecords in `all_records`.
+    This will consume the `all_records` iterator, and requires enough memory to
+    be able to read it entirely.
+    `key_fields` optionally contains the fields over which to aggregate. By
+    default it's the typical flow 5-tuple.
+    """
+    flow_table = defaultdict(_FlowStats)
+    for flow_record in all_records:
+        key = tuple(getattr(flow_record, attr) for attr in key_fields)
+        flow_table[key].update(flow_record)
+
+    for key in flow_table:
+        item = {k: v for k, v in zip(key_fields, key)}
+        item.update(flow_table[key].to_dict())
+        yield item

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -86,9 +86,12 @@ class FlowRecord(object):
             self.action = fields[12]
 
     def __eq__(self, other):
-        return all(
-            getattr(self, x) == getattr(other, x) for x in self.__slots__
-        )
+        try:
+            return all(
+                getattr(self, x) == getattr(other, x) for x in self.__slots__
+            )
+        except AttributeError:
+            return False
 
     def __hash__(self):
         return hash(tuple(getattr(self, x) for x in self.__slots__))

--- a/tests/test_flowlogs_reader.py
+++ b/tests/test_flowlogs_reader.py
@@ -75,25 +75,13 @@ class FlowRecordTestCase(TestCase):
         self.assertEqual(actual, expected)
 
     def test_eq(self):
-        flow_record = FlowRecord({'message': SAMPLE_RECORDS[1]})
-        actual = {x: getattr(flow_record, x) for x in FlowRecord.__slots__}
-        expected = {
-            'account_id': '123456789010',
-            'action': 'ACCEPT',
-            'bytes': 1680,
-            'dstaddr': '198.51.100.1',
-            'dstport': 443,
-            'end': datetime(2015, 8, 12, 13, 47, 45),
-            'interface_id': 'eni-102010ab',
-            'log_status': 'OK',
-            'packets': 20,
-            'protocol': 6,
-            'srcaddr': '192.0.2.1',
-            'srcport': 49152,
-            'start': datetime(2015, 8, 12, 13, 47, 44),
-            'version': 2,
-        }
-        self.assertEqual(actual, expected)
+        flow_record = FlowRecord({'message': SAMPLE_RECORDS[0]})
+        equal_record = FlowRecord({'message': SAMPLE_RECORDS[0]})
+        unequal_record = FlowRecord({'message': SAMPLE_RECORDS[1]})
+
+        self.assertEqual(flow_record, equal_record)
+        self.assertNotEqual(flow_record, unequal_record)
+        self.assertNotEqual(flow_record, Ellipsis)
 
     def test_hash(self):
         record_set = {

--- a/tests/test_flowlogs_reader.py
+++ b/tests/test_flowlogs_reader.py
@@ -251,6 +251,7 @@ class AggregationTestCase(TestCase):
             SAMPLE_RECORDS[0],
             SAMPLE_RECORDS[1],
             SAMPLE_RECORDS[2].replace('REJECT', 'ACCEPT'),
+            SAMPLE_RECORDS[3],
         ]
         all_records = (FlowRecord.from_message(x) for x in messages)
         results = aggregated_records(all_records)

--- a/tests/test_flowlogs_reader.py
+++ b/tests/test_flowlogs_reader.py
@@ -17,7 +17,6 @@ from __future__ import division, print_function
 from datetime import datetime
 from unittest import TestCase
 
-
 from botocore.exceptions import NoRegionError
 
 try:
@@ -25,7 +24,7 @@ try:
 except ImportError:
     from mock import MagicMock, patch
 
-from flowlogs_reader import FlowRecord, FlowLogsReader
+from flowlogs_reader import aggregated_records, FlowRecord, FlowLogsReader
 from flowlogs_reader.flowlogs_reader import DEFAULT_REGION_NAME
 
 
@@ -39,8 +38,8 @@ SAMPLE_RECORDS = [
         '49152 443 6 20 1680 1439387264 1439387265 ACCEPT OK'
     ),
     (
-        '2 123456789010 eni-102010ab 192.0.2.1 198.51.100.1 '
-        '49152 443 6 20 1680 1439387265 1439387266 REJECT OK'
+        '2 123456789010 eni-102010cd 192.0.2.1 198.51.100.1 '
+        '49152 443 6 20 1680 1439387263 1439387266 REJECT OK'
     ),
     (
         '2 123456789010 eni-1a2b3c4d - - - - - - - '
@@ -129,13 +128,13 @@ class FlowRecordTestCase(TestCase):
             'dstaddr': '198.51.100.1',
             'dstport': 443,
             'end': datetime(2015, 8, 12, 13, 47, 46),
-            'interface_id': 'eni-102010ab',
+            'interface_id': 'eni-102010cd',
             'log_status': 'OK',
             'packets': 20,
             'protocol': 6,
             'srcaddr': '192.0.2.1',
             'srcport': 49152,
-            'start': datetime(2015, 8, 12, 13, 47, 45),
+            'start': datetime(2015, 8, 12, 13, 47, 43),
             'version': 2,
         }
         self.assertEqual(actual, expected)
@@ -254,4 +253,78 @@ class FlowLogsReaderTestCase(TestCase):
         # Calling list on the instance causes it to iterate through all records
         actual = [next(self.inst)] + list(self.inst)
         expected = [FlowRecord.from_message(x) for x in SAMPLE_RECORDS]
+        self.assertEqual(actual, expected)
+
+
+class AggregationTestCase(TestCase):
+    def test_aggregated_records(self):
+        # Aggregate by 5-tuple by default
+        messages = [
+            SAMPLE_RECORDS[0],
+            SAMPLE_RECORDS[1],
+            SAMPLE_RECORDS[2].replace('REJECT', 'ACCEPT'),
+        ]
+        all_records = (FlowRecord.from_message(x) for x in messages)
+        results = aggregated_records(all_records)
+
+        actual = sorted(results, key=lambda x: x['srcaddr'])
+        expected = [
+            {
+                'srcaddr': '192.0.2.1',
+                'srcport': 49152,
+                'dstaddr': '198.51.100.1',
+                'dstport': 443,
+                'protocol': 6,
+                'start': datetime(2015, 8, 12, 13, 47, 43),
+                'end': datetime(2015, 8, 12, 13, 47, 46),
+                'packets': 40,
+                'bytes': 3360,
+            },
+            {
+                'srcaddr': '198.51.100.1',
+                'srcport': 443,
+                'dstaddr': '192.0.2.1',
+                'dstport': 49152,
+                'protocol': 6,
+                'start': datetime(2015, 8, 12, 13, 47, 43),
+                'end': datetime(2015, 8, 12, 13, 47, 44),
+                'packets': 10,
+                'bytes': 840,
+            },
+        ]
+        self.assertEqual(actual, expected)
+
+    def test_aggregated_records_custom(self):
+        # Aggregate by interface_id
+        messages = [
+            SAMPLE_RECORDS[1],
+            SAMPLE_RECORDS[2].replace('REJECT', 'ACCEPT'),
+        ]
+        all_records = (FlowRecord.from_message(x) for x in messages)
+        key_fields = ('interface_id', 'srcaddr', 'srcport', 'dstport')
+        results = aggregated_records(all_records, key_fields=key_fields)
+
+        actual = sorted(results, key=lambda x: x['interface_id'])
+        expected = [
+            {
+                'srcaddr': '192.0.2.1',
+                'srcport': 49152,
+                'interface_id': 'eni-102010ab',
+                'dstport': 443,
+                'start': datetime(2015, 8, 12, 13, 47, 44),
+                'end': datetime(2015, 8, 12, 13, 47, 45),
+                'packets': 20,
+                'bytes': 1680,
+            },
+            {
+                'srcaddr': '192.0.2.1',
+                'srcport': 49152,
+                'interface_id': 'eni-102010cd',
+                'dstport': 443,
+                'start': datetime(2015, 8, 12, 13, 47, 43),
+                'end': datetime(2015, 8, 12, 13, 47, 46),
+                'packets': 20,
+                'bytes': 1680,
+            },
+        ]
         self.assertEqual(actual, expected)


### PR DESCRIPTION
VPC flow logs do aggregation already, but across larger time windows you have to do it yourself. This PR adds a library function and CLI action to compute time windows and traffic totals for all records from a query.

This is unidirectional aggregation and thus keeps the same field names as are in the original flow records. I may do bidirectional aggregation in another PR later.