### PR TITLE
Catch PaginationError

### DIFF
--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -18,8 +18,7 @@ from calendar import timegm
 from datetime import datetime, timedelta
 
 import boto3
-from botocore.exceptions import NoRegionError
-
+from botocore.exceptions import NoRegionError, PaginationError
 
 DEFAULT_FILTER_PATTERN = (
     '[version="2", account_id, interface_id, srcaddr, dstaddr, '
@@ -212,9 +211,12 @@ class FlowLogsReader(object):
             **self.paginator_kwargs
         )
 
-        for page in response_iterator:
-            for event in page['events']:
-                yield event
+        try:
+            for page in response_iterator:
+                for event in page['events']:
+                    yield event
+        except PaginationError:
+            pass
 
     def _reader(self):
         # Loops through each log stream and its events, yielding a parsed

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -26,6 +26,7 @@ DEFAULT_FILTER_PATTERN = (
     'start, end, action, log_status]'
 )
 DEFAULT_REGION_NAME = 'us-east-1'
+DUPLICATE_NEXT_TOKEN_MESSAGE = 'The same next token was received twice'
 
 ACCEPT = 'ACCEPT'
 REJECT = 'REJECT'
@@ -215,8 +216,11 @@ class FlowLogsReader(object):
             for page in response_iterator:
                 for event in page['events']:
                     yield event
-        except PaginationError:
-            pass
+        except PaginationError as e:
+            if e.kwargs['message'].startswith(DUPLICATE_NEXT_TOKEN_MESSAGE):
+                pass
+            else:
+                raise
 
     def _reader(self):
         # Loops through each log stream and its events, yielding a parsed


### PR DESCRIPTION
Re: #27, this PR catches `PaginationError` such that the iterator doesn't fail if botocore returns the same `nextToken` twice.

I considered adding a log entry for this case, but I'd like to get [logging ettiquette](https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library) right since this is a library, and that seems outside the scope of the issue here.