### PR TITLE
Support for undocumented millisecond timestamps

### DIFF
--- a/flowlogs_reader/__main__.py
+++ b/flowlogs_reader/__main__.py
@@ -42,6 +42,8 @@ def action_print(reader, *args):
         print(record.to_message())
         if i == stop_after:
             break
+
+
 actions['print'] = action_print
 
 
@@ -56,6 +58,8 @@ def action_ipset(reader, *args):
 
     for ip in ip_set:
         print(ip)
+
+
 actions['ipset'] = action_ipset
 
 
@@ -65,6 +69,8 @@ def action_findip(reader, *args):
     for record in reader:
         if (record.srcaddr in target_ips) or (record.dstaddr in target_ips):
             print(record.to_message())
+
+
 actions['findip'] = action_findip
 
 
@@ -79,6 +85,8 @@ def action_aggregate(reader, *args):
     iterable = chain([first_row], all_aggregated)
     for item in iterable:
         print(*[item[k] for k in keys], sep='\t')
+
+
 actions['aggregate'] = action_aggregate
 
 

--- a/tests/test_flowlogs_reader.py
+++ b/tests/test_flowlogs_reader.py
@@ -130,6 +130,16 @@ class FlowRecordTestCase(TestCase):
         }
         self.assertEqual(actual, expected)
 
+    def test_millisecond_timestamp(self):
+        # This record has millisecond timestamps
+        record = (
+            '2 123456789010 eni-4b118871 - - - - - - - '
+            '1512564058000 1512564059000 - SKIPDATA'
+        )
+        flow_record = FlowRecord({'message': record})
+        self.assertEqual(flow_record.start, datetime(2017, 12, 6, 12, 40, 58))
+        self.assertEqual(flow_record.end, datetime(2017, 12, 6, 12, 40, 59))
+
     def test_to_message(self):
         for message in SAMPLE_RECORDS:
             message_record = FlowRecord.from_message(message)


### PR DESCRIPTION
This PR adds support for flow records that use millisecond-based timestamps. These are undocumented as of this writing, but can be seen in the wild.

![image](https://user-images.githubusercontent.com/1922815/33668180-a0dab704-da64-11e7-8181-a411ccc9c732.png)
