### PR TITLE
Read VPC Flow Logs from S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ __Location types__
 
 To use an S3 location, specify `--location-type='s3'`:
 
-* `flowlogs_reader "bucket-name/optional-prefix"`
+* `flowlogs_reader --location-type="s3" "bucket-name/optional-prefix"`
 
 __Printing flows__
 
@@ -88,8 +88,8 @@ For CloudWatch Logs locations:
 
 For S3 locations:
 
-* `flowlogs_reader --include-accounts='12345678901,12345678902'` - return logs only for the given accounts
-* `flowlogs_reader --include-regions='us-east-1,us-east-2'` - return logs only for the given regions
+* `flowlogs_reader --location-type='s3' --include-accounts='12345678901,12345678902' bucket-name/optional-prefix` - return logs only for the given accounts
+* `flowlogs_reader --location-type='s3' --include-regions='us-east-1,us-east-2' bucket-name/optional-prefix` - return logs only for the given regions
 
 
 ## Module Usage

--- a/flowlogs_reader/__init__.py
+++ b/flowlogs_reader/__init__.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .aggregation import aggregated_records  # noqa
-from .flowlogs_reader import FlowRecord, FlowLogsReader  # noqa
+from .aggregation import aggregated_records
+from .flowlogs_reader import FlowRecord, FlowLogsReader, S3FlowLogsReader
 
-__all__ = ['aggregated_records', 'FlowRecord', 'FlowLogsReader']
+__all__ = [
+    'aggregated_records', 'FlowRecord', 'FlowLogsReader', 'S3FlowLogsReader'
+]

--- a/flowlogs_reader/__main__.py
+++ b/flowlogs_reader/__main__.py
@@ -111,8 +111,18 @@ def get_reader(args):
     if args.end_time:
         kwargs['end_time'] = datetime.strptime(args.end_time, time_format)
 
-    if args.filter_pattern:
+    if args.location_type == 'cwl' and args.filter_pattern:
         kwargs['filter_pattern'] = args.filter_pattern
+
+    if args.location_type == 's3' and args.include_accounts:
+        kwargs['include_accounts'] = [
+            x.strip() for x in args.include_accounts.split(',')
+        ]
+
+    if args.location_type == 's3' and args.include_regions:
+        kwargs['include_regions'] = [
+            x.strip() for x in args.include_regions.split(',')
+        ]
 
     # Switch roles for access to another account
     if args.role_arn:
@@ -139,6 +149,7 @@ def get_reader(args):
 def main(argv=None):
     argv = argv or sys.argv[1:]
     parser = ArgumentParser(description='Read VPC Flow Log Records')
+    # Required paramters
     parser.add_argument(
         'location',
         type=str,
@@ -146,6 +157,7 @@ def main(argv=None):
     )
     parser.add_argument('action', type=str, nargs='*', default=['print'],
                         help='action to take on log records')
+    # Location paramters
     parser.add_argument(
         '--location-type',
         type=str,
@@ -153,20 +165,49 @@ def main(argv=None):
         choices=['cwl', 's3'],
         default='cwl'
     )
-    parser.add_argument('--profile', type=str, default='',
-                        help='boto3 configuration profile to use')
-    parser.add_argument('--region', type=str, default='',
-                        help='AWS region for the location')
-    parser.add_argument('--start-time', '-s', type=str,
-                        help='filter stream records at or after this time')
-    parser.add_argument('--end-time', '-e', type=str,
-                        help='filter stream records before this time')
+    parser.add_argument(
+        '--region',
+        type=str,
+        default='',
+        help='AWS region for the location'
+    )
+    # Time filter paramters
+    parser.add_argument(
+        '--start-time',
+        '-s',
+        type=str,
+        help='return records at or after this time'
+    )
+    parser.add_argument(
+        '--end-time',
+        '-e',
+        type=str,
+        help='return records before this time'
+    )
     parser.add_argument('--time-format', type=str, default='%Y-%m-%d %H:%M:%S',
                         help='format of time to parse')
+    # Other filtering parameters
     parser.add_argument(
         '--filter-pattern',
         type=str,
         help='return records that match this pattern (CWL only)'
+    )
+    parser.add_argument(
+        '--include-accounts',
+        type=str,
+        help='comma-separated list of accounts to consider (S3 only)'
+    )
+    parser.add_argument(
+        '--include-regions',
+        type=str,
+        help='comma-separated list of regions to consider (S3 only)'
+    )
+    # AWS paramters
+    parser.add_argument(
+        '--profile',
+        type=str,
+        default='',
+        help='boto3 configuration profile to use'
     )
     parser.add_argument('--role-arn', type=str,
                         help='assume role specified by this ARN')

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -258,19 +258,19 @@ class FlowLogsReader(BaseReader):
 class S3FlowLogsReader(BaseReader):
     def __init__(
         self,
-        destination,
+        location,
         include_accounts=None,
         include_regions=None,
         **kwargs
     ):
         super(S3FlowLogsReader, self).__init__('s3', **kwargs)
-        destination_parts = destination.split('/', 1)
-        if len(destination_parts) == 1:
-            self.bucket = destination_parts[0]
+        location_parts = location.split('/', 1)
+        if len(location_parts) == 1:
+            self.bucket = location_parts[0]
             self.prefix = ''
         else:
-            self.bucket = destination_parts[0]
-            self.prefix = destination_parts[1]
+            self.bucket = location_parts[0]
+            self.prefix = location_parts[1]
 
         self.include_accounts = (
             None if include_accounts is None else set(include_accounts)

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -261,6 +261,7 @@ class S3FlowLogsReader(BaseReader):
         destination_parts = destination.split('/', 1)
         if len(destination_parts) == 1:
             self.bucket = destination_parts[0]
+            self.prefix = ''
         else:
             self.bucket = destination_parts[0]
             self.prefix = destination_parts[1]

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -133,7 +133,73 @@ class FlowRecord(object):
         return cls({'message': message})
 
 
-class FlowLogsReader(object):
+class BaseReader(object):
+    def __init__(
+        self,
+        client_type,
+        region_name=None,
+        profile_name=None,
+        start_time=None,
+        end_time=None,
+        boto_client_kwargs=None,
+        boto_client=None,
+    ):
+        # Get a boto3 client with which to perform queries
+        if boto_client is not None:
+            self.boto_client = boto_client
+        else:
+            self.boto_client = self._get_client(
+                client_type, region_name, profile_name, boto_client_kwargs
+            )
+
+        # If no time filters are given use the last hour
+        now = datetime.utcnow()
+        self.start_time = start_time or now - timedelta(hours=1)
+        self.end_time = end_time or now
+
+        # Initialize the iterator
+        self.iterator = self._reader()
+
+    def _get_client(
+        self, client_type, region_name, profile_name, boto_client_kwargs
+    ):
+        session_kwargs = {}
+        if region_name is not None:
+            session_kwargs['region_name'] = region_name
+
+        if profile_name is not None:
+            session_kwargs['profile_name'] = profile_name
+
+        client_kwargs = boto_client_kwargs or {}
+
+        session = boto3.session.Session(**session_kwargs)
+        try:
+            boto_client = session.client(client_type, **client_kwargs)
+        except NoRegionError:
+            boto_client = session.client(
+                client_type, region_name=DEFAULT_REGION_NAME, **client_kwargs
+            )
+
+        return boto_client
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        return next(self.iterator)
+
+    def next(self):
+        # For Python 2 compatibility
+        return self.__next__()
+
+    def _reader(self):
+        # Loops through each log stream and its events, yielding a parsed
+        # version of each event.
+        for event in self._read_streams():
+            yield FlowRecord(event)
+
+
+class FlowLogsReader(BaseReader):
     """
     Returns an object that will yield VPC Flow Log records as Python objects.
     * `log_group_name` is the name of the CloudWatch Logs group that stores
@@ -151,22 +217,9 @@ class FlowLogsReader(object):
     """
 
     def __init__(
-        self,
-        log_group_name,
-        region_name=None,
-        profile_name=None,
-        start_time=None,
-        end_time=None,
-        filter_pattern=DEFAULT_FILTER_PATTERN,
-        boto_client_kwargs=None,
-        boto_client=None,
+        self, log_group_name, filter_pattern=DEFAULT_FILTER_PATTERN, **kwargs
     ):
-        if boto_client is not None:
-            self.logs_client = boto_client
-        else:
-            self.logs_client = self._get_client(
-                region_name, profile_name, boto_client_kwargs
-            )
+        super(FlowLogsReader, self).__init__('logs', **kwargs)
         self.log_group_name = log_group_name
 
         self.paginator_kwargs = {}
@@ -174,48 +227,11 @@ class FlowLogsReader(object):
         if filter_pattern is not None:
             self.paginator_kwargs['filterPattern'] = filter_pattern
 
-        # If no time filters are given use the last hour
-        now = datetime.utcnow()
-        start_time = start_time or now - timedelta(hours=1)
-        end_time = end_time or now
-
-        self.start_ms = timegm(start_time.utctimetuple()) * 1000
-        self.end_ms = timegm(end_time.utctimetuple()) * 1000
-
-        self.iterator = self._reader()
-
-    def __iter__(self):
-        return self
-
-    def __next__(self):
-        return next(self.iterator)
-
-    def next(self):
-        # For Python 2 compatibility
-        return self.__next__()
-
-    def _get_client(self, region_name, profile_name, boto_client_kwargs):
-        session_kwargs = {}
-        if region_name is not None:
-            session_kwargs['region_name'] = region_name
-
-        if profile_name is not None:
-            session_kwargs['profile_name'] = profile_name
-
-        client_kwargs = boto_client_kwargs or {}
-
-        session = boto3.session.Session(**session_kwargs)
-        try:
-            logs_client = session.client('logs', **client_kwargs)
-        except NoRegionError:
-            logs_client = session.client(
-                'logs', region_name=DEFAULT_REGION_NAME, **client_kwargs
-            )
-
-        return logs_client
+        self.start_ms = timegm(self.start_time.utctimetuple()) * 1000
+        self.end_ms = timegm(self.end_time.utctimetuple()) * 1000
 
     def _read_streams(self):
-        paginator = self.logs_client.get_paginator('filter_log_events')
+        paginator = self.boto_client.get_paginator('filter_log_events')
         response_iterator = paginator.paginate(
             logGroupName=self.log_group_name,
             startTime=self.start_ms,
@@ -233,9 +249,3 @@ class FlowLogsReader(object):
                 pass
             else:
                 raise
-
-    def _reader(self):
-        # Loops through each log stream and its events, yielding a parsed
-        # version of each event.
-        for event in self._read_streams():
-            yield FlowRecord(event)

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -340,7 +340,8 @@ class S3FlowLogsReader(BaseReader):
     def _get_account_prefixes(self):
         # Yield each prefix of the type:
         # base_location/AWSLogs/account_number/
-        prefix = self.prefix.rstrip('/') + '/AWSLogs/'
+        prefix = self.prefix.strip('/') + '/AWSLogs/'
+        prefix = prefix.lstrip('/')
         resp = self.boto_client.list_objects_v2(
             Bucket=self.bucket, Delimiter='/', Prefix=prefix
         )

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -264,13 +264,9 @@ class S3FlowLogsReader(BaseReader):
         **kwargs
     ):
         super(S3FlowLogsReader, self).__init__('s3', **kwargs)
-        location_parts = location.split('/', 1)
-        if len(location_parts) == 1:
-            self.bucket = location_parts[0]
-            self.prefix = ''
-        else:
-            self.bucket = location_parts[0]
-            self.prefix = location_parts[1]
+
+        location_parts = (location.rstrip('/') + '/').split('/', 1)
+        self.bucket, self.prefix = location_parts
 
         self.include_accounts = (
             None if include_accounts is None else set(include_accounts)

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
     install_requires=[
         'boto3>=1.7.75',
         'botocore>=1.10.75',
+        'python-dateutil>=2.7.0'
     ],
     tests_require=['mock'] if PY2 else [],
 )

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,9 @@ setup(
     packages=find_packages(exclude=[]),
     test_suite='tests',
 
-    install_requires=['botocore>=1.2.0', 'boto3>=1.1.3'],
+    install_requires=[
+        'boto3>=1.7.75',
+        'botocore>=1.10.75',
+    ],
     tests_require=['mock'] if PY2 else [],
 )

--- a/tests/test_flowlogs_reader.py
+++ b/tests/test_flowlogs_reader.py
@@ -314,7 +314,12 @@ class S3FlowLogsReaderTestCase(TestCase):
             # Accounts call
             accounts_response = {
                 'ResponseMetadata': {'HTTPStatusCode': 200},
-                'CommonPrefixes': [{'Prefix': '/AWSLogs/123456789010/'}]
+                'CommonPrefixes': [
+                    # This one is used
+                    {'Prefix': '/AWSLogs/123456789010/'},
+                    # This one is ignored
+                    {'Prefix': '/AWSLogs/123456789011/'},
+                ]
             }
             accounts_params = {
                 'Bucket': 'example-bucket',
@@ -328,7 +333,10 @@ class S3FlowLogsReaderTestCase(TestCase):
             regions_response = {
                 'ResponseMetadata': {'HTTPStatusCode': 200},
                 'CommonPrefixes': [
-                    {'Prefix': '/AWSLogs/123456789010/vpcflowlogs/pangaea-1/'}
+                    # This one is used
+                    {'Prefix': '/AWSLogs/123456789010/vpcflowlogs/pangaea-1/'},
+                    # This one is ignored
+                    {'Prefix': '/AWSLogs/123456789010/vpcflowlogs/pangaea-2/'},
                 ]
             }
             regions_params = {
@@ -363,6 +371,13 @@ class S3FlowLogsReaderTestCase(TestCase):
                             'pangaea-1_fl-102010_'
                             '20150812T1200Z_'
                             'h45h.log.gz'
+                        ),
+                    },
+                    # Some fool put a different key here
+                    {
+                        'Key': (
+                            '/AWSLogs/123456789010/vpcflowlogs/pangaea-1/'
+                            '2015/08/12/test_file.log.gz'
                         ),
                     },
                 ]
@@ -408,6 +423,8 @@ class S3FlowLogsReaderTestCase(TestCase):
                 'example-bucket',
                 start_time=self.start_time,
                 end_time=self.end_time,
+                include_accounts={'123456789010'},
+                include_regions={'pangaea-1'},
                 boto_client=boto_client,
             )
             actual = list(reader)

--- a/tests/test_flowlogs_reader.py
+++ b/tests/test_flowlogs_reader.py
@@ -15,7 +15,7 @@
 from __future__ import division, print_function
 
 from datetime import datetime
-from gzip import open as gz_open
+from gzip import GzipFile
 from io import BytesIO
 from unittest import TestCase
 
@@ -395,8 +395,8 @@ class S3FlowLogsReaderTestCase(TestCase):
             header = ' '.join(FlowRecord.__slots__)
             text = '\n'.join([header] + SAMPLE_RECORDS)
             with BytesIO() as f:
-                with gz_open(f, 'wt') as gz_f:
-                    gz_f.write(text)
+                with GzipFile(fileobj=f, mode='wb') as gz_f:
+                    gz_f.write(text.encode('utf-8'))
                 data = f.getvalue()
 
             get_response = {

--- a/tests/test_flowlogs_reader.py
+++ b/tests/test_flowlogs_reader.py
@@ -316,15 +316,15 @@ class S3FlowLogsReaderTestCase(TestCase):
                 'ResponseMetadata': {'HTTPStatusCode': 200},
                 'CommonPrefixes': [
                     # This one is used
-                    {'Prefix': '/AWSLogs/123456789010/'},
+                    {'Prefix': 'AWSLogs/123456789010/'},
                     # This one is ignored
-                    {'Prefix': '/AWSLogs/123456789011/'},
+                    {'Prefix': 'AWSLogs/123456789011/'},
                 ]
             }
             accounts_params = {
                 'Bucket': 'example-bucket',
                 'Delimiter': '/',
-                'Prefix': '/AWSLogs/'
+                'Prefix': 'AWSLogs/'
             }
             stubbed_client.add_response(
                 'list_objects_v2', accounts_response, accounts_params
@@ -334,15 +334,15 @@ class S3FlowLogsReaderTestCase(TestCase):
                 'ResponseMetadata': {'HTTPStatusCode': 200},
                 'CommonPrefixes': [
                     # This one is used
-                    {'Prefix': '/AWSLogs/123456789010/vpcflowlogs/pangaea-1/'},
+                    {'Prefix': 'AWSLogs/123456789010/vpcflowlogs/pangaea-1/'},
                     # This one is ignored
-                    {'Prefix': '/AWSLogs/123456789010/vpcflowlogs/pangaea-2/'},
+                    {'Prefix': 'AWSLogs/123456789010/vpcflowlogs/pangaea-2/'},
                 ]
             }
             regions_params = {
                 'Bucket': 'example-bucket',
                 'Delimiter': '/',
-                'Prefix': '/AWSLogs/123456789010/vpcflowlogs/'
+                'Prefix': 'AWSLogs/123456789010/vpcflowlogs/'
             }
             stubbed_client.add_response(
                 'list_objects_v2', regions_response, regions_params
@@ -354,7 +354,7 @@ class S3FlowLogsReaderTestCase(TestCase):
                     # Too early - not downloaded
                     {
                         'Key': (
-                            '/AWSLogs/123456789010/vpcflowlogs/pangaea-1/'
+                            'AWSLogs/123456789010/vpcflowlogs/pangaea-1/'
                             '2015/08/12/'
                             '123456789010_vpcflowlogs_'
                             'pangaea-1_fl-102010_'
@@ -365,7 +365,7 @@ class S3FlowLogsReaderTestCase(TestCase):
                     # Right on time
                     {
                         'Key': (
-                            '/AWSLogs/123456789010/vpcflowlogs/pangaea-1/'
+                            'AWSLogs/123456789010/vpcflowlogs/pangaea-1/'
                             '2015/08/12/'
                             '123456789010_vpcflowlogs_'
                             'pangaea-1_fl-102010_'
@@ -376,7 +376,7 @@ class S3FlowLogsReaderTestCase(TestCase):
                     # Some fool put a different key here
                     {
                         'Key': (
-                            '/AWSLogs/123456789010/vpcflowlogs/pangaea-1/'
+                            'AWSLogs/123456789010/vpcflowlogs/pangaea-1/'
                             '2015/08/12/test_file.log.gz'
                         ),
                     },
@@ -385,7 +385,7 @@ class S3FlowLogsReaderTestCase(TestCase):
             list_params = {
                 'Bucket': 'example-bucket',
                 'Prefix': (
-                    '/AWSLogs/123456789010/vpcflowlogs/pangaea-1/2015/08/12/'
+                    'AWSLogs/123456789010/vpcflowlogs/pangaea-1/2015/08/12/'
                 )
             }
             stubbed_client.add_response(
@@ -406,7 +406,7 @@ class S3FlowLogsReaderTestCase(TestCase):
             get_params = {
                 'Bucket': 'example-bucket',
                 'Key': (
-                    '/AWSLogs/123456789010/vpcflowlogs/pangaea-1/'
+                    'AWSLogs/123456789010/vpcflowlogs/pangaea-1/'
                     '2015/08/12/'
                     '123456789010_vpcflowlogs_'
                     'pangaea-1_fl-102010_'


### PR DESCRIPTION
Last week AWS added support for delivering VPC Flow Logs to S3 destinations.

This PR adds support for pulling log files from S3.

It introduces the `S3FlowLogsReader` class, which is similar to `FlowLogsReader`. It of course does not support CloudWatch Logs `filter_pattern` arguments, but does support optional filtering with `include_accounts` and `include_regions`.