### PR TITLE
Let's just classify for Python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,9 +39,6 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
This PR updates `setup.py` to say we support Python 3, and removes the breakout for 3.3, 3.4, and 3.5.

This repo will support all the versions of Python currently supported by Python.org (currently 2.7 and 3.4+).