### PR TITLE
Don't install a top-level `tests` package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ install_requires =
 
 [options.packages.find]
 exclude =
-    test
+    tests
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,10 @@ install_requires =
     botocore>=1.10.75
     python-dateutil>=2.7.0
 
+[options.packages.find]
+exclude =
+    test
+
 [options.entry_points]
 console_scripts =
     flowlogs_reader = flowlogs_reader.__main__:main


### PR DESCRIPTION
fixes https://github.com/obsrvbl/flowlogs-reader/issues/42

before:
```bash
python setup.py bdist_wheel
cat flowlogs_reader.egg-info/top_level.txt
# flowlogs_reader
# tests
```

after:
```bash
python setup.py bdist_wheel
cat flowlogs_reader.egg-info/top_level.txt
# flowlogs_reader
```
