### PR TITLE
Multi-threaded reader for Cloudwatch Logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ The default time window is the last hour. You may also specify a `--start-time` 
 
 Use the `--time-format` switch to control how start and end times are interpreted. The default is `'%Y-%m-%d %H:%M:%S'`. See the Python documentation for `strptime` for information on format strings.
 
-__Concurrent reads (S3 only)__
+__Concurrent reads__
 
-Give `--thread-count` to read from multiple S3 keys at once:
+Give `--thread-count` to read from multiple log groups or S3 keys at once:
 
 * `flowlogs_reader --thread_count=4 location`
 

--- a/flowlogs_reader/__init__.py
+++ b/flowlogs_reader/__init__.py
@@ -13,8 +13,15 @@
 # limitations under the License.
 
 from .aggregation import aggregated_records
-from .flowlogs_reader import FlowRecord, FlowLogsReader, S3FlowLogsReader
+from .flowlogs_reader import (
+    FlowRecord,
+    FlowLogsReader,
+    S3FlowLogsReader,
+)
 
 __all__ = [
-    'aggregated_records', 'FlowRecord', 'FlowLogsReader', 'S3FlowLogsReader'
+    'aggregated_records',
+    'FlowRecord',
+    'FlowLogsReader',
+    'S3FlowLogsReader',
 ]

--- a/flowlogs_reader/__main__.py
+++ b/flowlogs_reader/__main__.py
@@ -21,7 +21,12 @@ from uuid import uuid4
 import boto3
 
 from .aggregation import aggregated_records
-from .flowlogs_reader import FlowLogsReader, S3FlowLogsReader, SKIPDATA, NODATA
+from .flowlogs_reader import (
+    FlowLogsReader,
+    NODATA,
+    S3FlowLogsReader,
+    SKIPDATA,
+)
 
 actions = {}
 
@@ -124,7 +129,7 @@ def get_reader(args):
             x.strip() for x in args.include_regions.split(',')
         ]
 
-    if args.location_type == 's3' and args.thread_count:
+    if args.thread_count:
         kwargs['thread_count'] = args.thread_count
 
     # Switch roles for access to another account
@@ -219,7 +224,7 @@ def main(argv=None):
     parser.add_argument(
         '--thread-count',
         type=int,
-        help='number of threads used when reading (S3 only)'
+        help='number of threads used when reading'
     )
     args = parser.parse_args(argv)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,3 +55,8 @@ exclude_lines =
     raise NotImplementedError
     if 0:
     if __name__ == .__main__.:
+
+[flake8]
+ignore =
+  # do not assign a lambda expression, use a def
+  E731

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from setuptools import setup, find_packages
+from setuptools import setup
 
 
 setup()


### PR DESCRIPTION
PR #40 added a multi-threaded reading capability to the S3 reader. This PR adds the same to the Cloudwatch Logs reader.

When `thread_count` is nonzero, the reader will:
* Retrieve the log streams that have events in the requested time window
* Set up a thread pool with the number of threads requested
* Read from each log stream in a separate thread