### PR TITLE
Version 2.2.1

### DIFF
--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -31,6 +31,10 @@ DEFAULT_FILTER_PATTERN = (
 DEFAULT_REGION_NAME = 'us-east-1'
 DUPLICATE_NEXT_TOKEN_MESSAGE = 'The same next token was received twice'
 
+# The lastEventTimestamp may be delayed by up to an hour:
+# https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_LogStream.html  # noqa
+LAST_EVENT_DELAY_MSEC = 3600000
+
 ACCEPT = 'ACCEPT'
 REJECT = 'REJECT'
 SKIPDATA = 'SKIPDATA'
@@ -273,7 +277,10 @@ class FlowLogsReader(BaseReader):
                 # Since we're ordering by last event timestamp, we're finished
                 # when we encounter a stream that ends before the time we
                 # care about.
-                if log_stream['lastEventTimestamp'] < self.start_ms:
+                last_event_ms = (
+                    log_stream['lastEventTimestamp'] + LAST_EVENT_DELAY_MSEC
+                )
+                if last_event_ms < self.start_ms:
                     break
 
                 yield log_stream['logStreamName']

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@
 
 [metadata]
 name = flowlogs_reader
-version = 2.2.0
+version = 2.2.1
 license = Apache
 url = https://github.com/obsrvbl/flowlogs-reader
 description = Reader for AWS VPC Flow Logs

--- a/tests/test_flowlogs_reader.py
+++ b/tests/test_flowlogs_reader.py
@@ -32,6 +32,7 @@ from flowlogs_reader import (
 from flowlogs_reader.flowlogs_reader import (
     DEFAULT_REGION_NAME,
     DUPLICATE_NEXT_TOKEN_MESSAGE,
+    LAST_EVENT_DELAY_MSEC,
 )
 
 
@@ -331,7 +332,9 @@ class FlowLogsReaderTestCase(TestCase):
                             {
                                 'logStreamName': 'too_late',
                                 'firstEventTimestamp': inst.end_ms - 1,
-                                'lastEventTimestamp': inst.start_ms - 1,
+                                'lastEventTimestamp': (
+                                    inst.start_ms - LAST_EVENT_DELAY_MSEC - 1
+                                ),
                             },
                         ],
                     },


### PR DESCRIPTION
This PR adds an offset to the `lastEventTimestamp` filter for multi-threaded CWL reading. As @mjschultz pointed out, the [docs](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_LogStream.html) say this:
> The lastEventTime value updates on an eventual consistency basis. It typically updates in less than an hour from ingestion, but may take longer in some rare situations. 