### PR TITLE
Test against 3.9-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
     - "3.6"
     - "3.7"
     - "3.8"
+    - "3.9-dev"
     - "pypy3"
 
 install:


### PR DESCRIPTION
This PR updates the Travis configuration file to add testing for Python 3.9.