### PR TITLE
Verison 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Other command line switches:
 
 For CloudWatch Logs locations:
 
+* `flowlogs_reader --fields='${version} ${account-id} ${interface-id} ${srcaddr} ${dstaddr} ${srcport} ${dstport} ${protocol} ${packets} ${bytes} ${start} ${end} ${action} ${log-status}'` - use the given `fields` to prevent the module from querying EC2 for the log line format
 * `flowlogs_reader --filter-pattern='REJECT' location` - use the given [filter pattern](http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/FilterAndPatternSyntax.html) to have the server limit the output
 
 For S3 locations:
@@ -154,6 +155,7 @@ You can control what's retrieved with these parameters:
 
 When using `FlowLogsReader` with CloudWatch Logs:
 
+* The `fields` keyword is a tuple like `('version', 'account-id')`. If not supplied then the EC2 API will be queried to find out the log format.
 * The `filter_pattern` keyword is a string like `REJECT` or `443` used to filter the logs. See the examples below.
 
 When using `S3FlowLogsReader` with S3:

--- a/README.md
+++ b/README.md
@@ -149,10 +149,8 @@ By default these classes will yield records from the last hour.
 
 You can control what's retrieved with these parameters:
 * `start_time` and `end_time` are Python `datetime.datetime` objects
-* `region_name` is a string like `'us-east-1'`. This will be used to create a [boto3 Session object](http://boto3.readthedocs.io/en/latest/reference/core/session.html#boto3.session.Session).
-* `profile_name` is a string like `'my-profile'`
-* `boto_client_kwargs` is a dictionary of parameters to pass when creating the [boto3 client](http://boto3.readthedocs.io/en/latest/reference/core/session.html#boto3.session.Session.client).
-* `boto_client` is a boto3 client object. This takes overrides `region_name`, `profile_name`, and `boto_client_kwargs`.
+* `region_name` is a string like `'us-east-1'`.
+* `boto_client` is a boto3 client object.
 
 When using `FlowLogsReader` with CloudWatch Logs:
 

--- a/flowlogs_reader/__main__.py
+++ b/flowlogs_reader/__main__.py
@@ -117,6 +117,9 @@ def get_reader(args):
     if args.end_time:
         kwargs['end_time'] = datetime.strptime(args.end_time, time_format)
 
+    if args.location_type == 'cwl' and args.fields:
+        kwargs['fields'] = tuple(x.strip('${}') for x in args.fields.split())
+
     if args.location_type == 'cwl' and args.filter_pattern:
         kwargs['filter_pattern'] = args.filter_pattern
 
@@ -199,6 +202,11 @@ def main(argv=None):
         help='format of time to parse',
     )
     # Other filtering parameters
+    parser.add_argument(
+        '--fields',
+        type=str,
+        help='Log line format (CWL only)',
+    )
     parser.add_argument(
         '--filter-pattern',
         type=str,

--- a/flowlogs_reader/__main__.py
+++ b/flowlogs_reader/__main__.py
@@ -100,6 +100,7 @@ def get_reader(args):
     if args.location_type == 'cwl':
         cls = FlowLogsReader
         client_type = 'logs'
+        kwargs['fields'] = None
     elif args.location_type == 's3':
         cls = S3FlowLogsReader
         client_type = 's3'

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -376,14 +376,13 @@ class S3FlowLogsReader(BaseReader):
     def _read_file(self, key):
         resp = self.boto_client.get_object(Bucket=self.bucket, Key=key)
         with gz_open(resp['Body'], mode='rt') as gz_f:
-            all_data = gz_f.read()
-            reader = DictReader(all_data.splitlines(), delimiter=' ')
+            reader = DictReader(gz_f, delimiter=' ')
             reader.fieldnames = [
                 f.replace('-', '_') for f in reader.fieldnames
             ]
             yield from reader
             with THREAD_LOCK:
-                self.bytes_processed += len(all_data)
+                self.bytes_processed += gz_f.tell()
 
     def _get_keys(self, prefix):
         # S3 keys have a file name like:

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -266,7 +266,9 @@ class FlowLogsReader(BaseReader):
         self.thread_count = thread_count
 
         if fields is None:
-            fields = self._get_fields(self.region_name, self.log_group_name)
+            fields = self._get_fields(
+                self.region_name, self.log_group_name, ec2_client=ec2_client
+            )
         self.fields = fields
 
         self.start_ms = timegm(self.start_time.utctimetuple()) * 1000

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -269,7 +269,7 @@ class FlowLogsReader(BaseReader):
             fields = self._get_fields(
                 self.region_name, self.log_group_name, ec2_client=ec2_client
             )
-        self.fields = fields
+        self.fields = tuple(f.replace('-', '_') for f in fields)
 
         self.start_ms = timegm(self.start_time.utctimetuple()) * 1000
         self.end_ms = timegm(self.end_time.utctimetuple()) * 1000

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -18,17 +18,29 @@ from csv import DictReader
 from datetime import datetime, timedelta
 from gzip import open as gz_open
 from os.path import basename
+from threading import Lock
 
 import boto3
-from botocore.exceptions import NoRegionError, PaginationError
+
+from botocore.exceptions import PaginationError
 from dateutil.rrule import rrule, DAILY
 
-DEFAULT_FILTER_PATTERN = (
-    '[version="2", account_id, interface_id, srcaddr, dstaddr, '
-    'srcport, dstport, protocol, packets, bytes, '
-    'start, end, action, log_status]'
+DEFAULT_FIELDS = (
+    'version',
+    'account_id',
+    'interface_id',
+    'srcaddr',
+    'dstaddr',
+    'srcport',
+    'dstport',
+    'protocol',
+    'packets',
+    'bytes',
+    'start',
+    'end',
+    'action',
+    'log_status',
 )
-DEFAULT_REGION_NAME = 'us-east-1'
 DUPLICATE_NEXT_TOKEN_MESSAGE = 'The same next token was received twice'
 
 # The lastEventTimestamp may be delayed by up to an hour:
@@ -39,6 +51,8 @@ ACCEPT = 'ACCEPT'
 REJECT = 'REJECT'
 SKIPDATA = 'SKIPDATA'
 NODATA = 'NODATA'
+
+THREAD_LOCK = Lock()
 
 
 class FlowRecord:
@@ -175,11 +189,11 @@ class FlowRecord:
         return ' '.join(ret)
 
     @classmethod
-    def from_cwl_event(cls, cwl_event):
-        fields = cwl_event['message'].split()
+    def from_cwl_event(cls, cwl_event, fields=DEFAULT_FIELDS):
+        data = cwl_event['message'].split()
 
         event_data = {}
-        for key, value in zip(cls.__slots__, fields):
+        for key, value in zip(fields, data):
             event_data[key] = value
 
         return cls(event_data)
@@ -190,49 +204,24 @@ class BaseReader:
         self,
         client_type,
         region_name=None,
-        profile_name=None,
         start_time=None,
         end_time=None,
-        boto_client_kwargs=None,
         boto_client=None,
     ):
-        # Get a boto3 client with which to perform queries
+        self.region_name = region_name
         if boto_client is not None:
             self.boto_client = boto_client
         else:
-            self.boto_client = self._get_client(
-                client_type, region_name, profile_name, boto_client_kwargs
-            )
+            kwargs = {'region_name': region_name} if region_name else {}
+            self.boto_client = boto3.client(client_type, **kwargs)
 
         # If no time filters are given use the last hour
         now = datetime.utcnow()
         self.start_time = start_time or now - timedelta(hours=1)
         self.end_time = end_time or now
 
-        # Initialize the iterator
+        self.bytes_processed = 0
         self.iterator = self._reader()
-
-    def _get_client(
-        self, client_type, region_name, profile_name, boto_client_kwargs
-    ):
-        session_kwargs = {}
-        if region_name is not None:
-            session_kwargs['region_name'] = region_name
-
-        if profile_name is not None:
-            session_kwargs['profile_name'] = profile_name
-
-        client_kwargs = boto_client_kwargs or {}
-
-        session = boto3.session.Session(**session_kwargs)
-        try:
-            boto_client = session.client(client_type, **client_kwargs)
-        except NoRegionError:
-            boto_client = session.client(
-                client_type, region_name=DEFAULT_REGION_NAME, **client_kwargs
-            )
-
-        return boto_client
 
     def __iter__(self):
         return self
@@ -261,22 +250,38 @@ class FlowLogsReader(BaseReader):
     def __init__(
         self,
         log_group_name,
-        filter_pattern=DEFAULT_FILTER_PATTERN,
+        filter_pattern=None,
         thread_count=0,
+        fields=DEFAULT_FIELDS,
+        ec2_client=None,
         **kwargs,
     ):
         super().__init__('logs', **kwargs)
         self.log_group_name = log_group_name
 
         self.paginator_kwargs = {}
-
         if filter_pattern is not None:
             self.paginator_kwargs['filterPattern'] = filter_pattern
 
         self.thread_count = thread_count
 
+        if fields is None:
+            fields = self._get_fields(self.region_name, self.log_group_name)
+        self.fields = fields
+
         self.start_ms = timegm(self.start_time.utctimetuple()) * 1000
         self.end_ms = timegm(self.end_time.utctimetuple()) * 1000
+
+    def _get_fields(self, region_name, log_group_name, ec2_client=None):
+        if ec2_client is None:
+            kwargs = {'region_name': region_name} if region_name else {}
+            ec2_client = boto3.client('ec2', **kwargs)
+
+        resp = ec2_client.describe_flow_logs(
+            Filters=[{'Name': 'log-group-name', 'Values': [log_group_name]}]
+        )
+        log_format = resp['FlowLogs'][0]['LogFormat']
+        return tuple(x.strip('${}') for x in log_format.split())
 
     def _get_log_streams(self):
         paginator = self.boto_client.get_paginator('describe_log_streams')
@@ -318,7 +323,13 @@ class FlowLogsReader(BaseReader):
 
         try:
             for page in response_iterator:
-                yield from page['events']
+                page_bytes = 0
+                for event in page.get('events', []):
+                    page_bytes += len(event['message'])
+                    yield event
+
+                with THREAD_LOCK:
+                    self.bytes_processed += page_bytes
         except PaginationError as e:
             if e.kwargs['message'].startswith(DUPLICATE_NEXT_TOKEN_MESSAGE):
                 pass
@@ -332,10 +343,10 @@ class FlowLogsReader(BaseReader):
                 func = lambda x: list(self._read_streams(x))
                 for events in executor.map(func, all_streams):
                     for event in events:
-                        yield FlowRecord.from_cwl_event(event)
+                        yield FlowRecord.from_cwl_event(event, self.fields)
         else:
             for event in self._read_streams():
-                yield FlowRecord.from_cwl_event(event)
+                yield FlowRecord.from_cwl_event(event, self.fields)
 
 
 class S3FlowLogsReader(BaseReader):
@@ -363,11 +374,14 @@ class S3FlowLogsReader(BaseReader):
     def _read_file(self, key):
         resp = self.boto_client.get_object(Bucket=self.bucket, Key=key)
         with gz_open(resp['Body'], mode='rt') as gz_f:
-            reader = DictReader(gz_f, delimiter=' ')
+            all_data = gz_f.read()
+            reader = DictReader(all_data.splitlines(), delimiter=' ')
             reader.fieldnames = [
                 f.replace('-', '_') for f in reader.fieldnames
             ]
             yield from reader
+            with THREAD_LOCK:
+                self.bytes_processed += len(all_data)
 
     def _get_keys(self, prefix):
         # S3 keys have a file name like:

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@
 
 [metadata]
 name = flowlogs_reader
-version = 2.4.0
+version = 3.0.0
 license = Apache
 url = https://github.com/obsrvbl/flowlogs-reader
 description = Reader for AWS VPC Flow Logs

--- a/tests/test_flowlogs_reader.py
+++ b/tests/test_flowlogs_reader.py
@@ -251,7 +251,7 @@ class FlowLogsReaderTestCase(TestCase):
         ec2_client = mock_client.return_value
         ec2_client.describe_flow_logs.return_value = {
             'FlowLogs': [
-                {'LogFormat': '${srcaddr} ${dstaddr} ${start} ${end}'}
+                {'LogFormat': '${srcaddr} ${dstaddr} ${start} ${log-status}'}
             ]
         }
         reader = FlowLogsReader(
@@ -259,7 +259,9 @@ class FlowLogsReaderTestCase(TestCase):
             boto_client=cwl_client,
             fields=None,
         )
-        self.assertEqual(reader.fields, ('srcaddr', 'dstaddr', 'start', 'end'))
+        self.assertEqual(
+            reader.fields, ('srcaddr', 'dstaddr', 'start', 'log_status')
+        )
         ec2_client.describe_flow_logs.assert_called_once_with(
             Filters=[{'Name': 'log-group-name', 'Values': ['some_group']}]
         )

--- a/tests/test_flowlogs_reader.py
+++ b/tests/test_flowlogs_reader.py
@@ -19,7 +19,7 @@ from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
 import boto3
-from botocore.exceptions import NoRegionError, PaginationError
+from botocore.exceptions import PaginationError
 from botocore.response import StreamingBody
 from botocore.stub import Stubber
 
@@ -30,7 +30,6 @@ from flowlogs_reader import (
     S3FlowLogsReader,
 )
 from flowlogs_reader.flowlogs_reader import (
-    DEFAULT_REGION_NAME,
     DUPLICATE_NEXT_TOKEN_MESSAGE,
     LAST_EVENT_DELAY_MSEC,
 )
@@ -236,54 +235,40 @@ class FlowLogsReaderTestCase(TestCase):
 
         self.assertEqual(self.inst.paginator_kwargs['filterPattern'], 'REJECT')
 
-    @patch('flowlogs_reader.flowlogs_reader.boto3.session', autospec=True)
-    def test_region_name(self, mock_session):
+    @patch('flowlogs_reader.flowlogs_reader.boto3.client', autospec=True)
+    def test_region_name(self, mock_client):
         # Region specified for session
         FlowLogsReader('some_group', region_name='some-region')
-        mock_session.Session.assert_called_with(region_name='some-region')
+        mock_client.assert_called_with('logs', region_name='some-region')
 
-        # Region specified for client, not for session
-        FlowLogsReader(
-            'some_group', boto_client_kwargs={'region_name': 'my-region'}
-        )
-        mock_session.Session().client.assert_called_with(
-            'logs', region_name='my-region'
-        )
-
-        # No region specified for session or client - use the default
-        def mock_response(*args, **kwargs):
-            if 'region_name' not in kwargs:
-                raise NoRegionError
-
-        mock_session.Session().client.side_effect = mock_response
-
+        # None specified
         FlowLogsReader('some_group')
-        mock_session.Session().client.assert_called_with(
-            'logs', region_name=DEFAULT_REGION_NAME
-        )
-
-    @patch('flowlogs_reader.flowlogs_reader.boto3.session', autospec=True)
-    def test_profile_name(self, mock_session):
-        # profile_name specified
-        FlowLogsReader('some_group', profile_name='my-profile')
-        mock_session.Session.assert_called_with(profile_name='my-profile')
-
-        # No profile specified
-        FlowLogsReader('some_group')
-        mock_session.Session.assert_called_with()
+        mock_client.assert_called_with('logs')
 
     def test_read_streams(self):
         paginator = MagicMock()
         paginator.paginate.return_value = [
-            {'events': [0]},
-            {'events': [1, 2]},
-            {'events': [3, 4, 5]},
+            {
+                'events': [
+                    {'logStreamName': 'log_0', 'message': V2_RECORDS[0]},
+                    {'logStreamName': 'log_0', 'message': V2_RECORDS[1]},
+                ],
+            },
+            {
+                'events': [
+                    {'logStreamName': 'log_0', 'message': V2_RECORDS[2]},
+                    {'logStreamName': 'log_1', 'message': V2_RECORDS[3]},
+                    {'logStreamName': 'log_2', 'message': V2_RECORDS[4]},
+                ],
+            },
         ]
 
         self.mock_client.get_paginator.return_value = paginator
 
         actual = list(self.inst._read_streams())
-        expected = [0, 1, 2, 3, 4, 5]
+        expected = []
+        for page in paginator.paginate.return_value:
+            expected += page['events']
         self.assertEqual(actual, expected)
 
     def test_iteration(self):
@@ -312,6 +297,13 @@ class FlowLogsReaderTestCase(TestCase):
             FlowRecord.from_cwl_event({'message': x}) for x in V2_RECORDS
         ]
         self.assertEqual(actual, expected)
+
+        expected_bytes = 0
+        all_pages = paginator.paginate.return_value
+        expected_bytes = sum(
+            len(e['message']) for p in all_pages for e in p['events']
+        )
+        self.assertEqual(self.inst.bytes_processed, expected_bytes)
 
     def test_iteration_error(self):
         # Simulate the paginator failing
@@ -543,6 +535,7 @@ class S3FlowLogsReaderTestCase(TestCase):
             get_response = {
                 'ResponseMetadata': {'HTTPStatusCode': 200},
                 'Body': StreamingBody(BytesIO(data), len(data)),
+                'ContentLength': len(data),
             }
             get_params = {
                 'Bucket': 'example-bucket',
@@ -569,6 +562,8 @@ class S3FlowLogsReaderTestCase(TestCase):
             )
             actual = [record.to_dict() for record in reader]
             self.assertEqual(actual, expected)
+
+        return reader
 
     def test_serial(self):
         expected = [
@@ -613,7 +608,8 @@ class S3FlowLogsReaderTestCase(TestCase):
                 'pkt_dstaddr': '192.168.0.1',
             },
         ]
-        self._test_iteration(V3_FILE, expected)
+        reader = self._test_iteration(V3_FILE, expected)
+        self.assertEqual(reader.bytes_processed, len(V3_FILE.encode()))
 
     def test_serial_v4(self):
         expected = [
@@ -667,7 +663,8 @@ class S3FlowLogsReaderTestCase(TestCase):
                 'sublocation_id': 'outpostid04',
             },
         ]
-        self._test_iteration(V4_FILE, expected)
+        reader = self._test_iteration(V4_FILE, expected)
+        self.assertEqual(reader.bytes_processed, len(V4_FILE.encode()))
 
     def test_serial_v5(self):
         expected = [
@@ -727,7 +724,8 @@ class S3FlowLogsReaderTestCase(TestCase):
                 'vpc_id': 'vpc-04456ab739938ee3f',
             },
         ]
-        self._test_iteration(V5_FILE, expected)
+        reader = self._test_iteration(V5_FILE, expected)
+        self.assertEqual(reader.bytes_processed, len(V5_FILE.encode()))
 
     def test_threads(self):
         expected = [

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -59,17 +59,19 @@ class MainTestCase(TestCase):
     @patch('flowlogs_reader.__main__.FlowLogsReader', autospec=True)
     def test_main(self, mock_reader):
         main(['mygroup'])
-        mock_reader.assert_called_with(log_group_name='mygroup')
+        mock_reader.assert_called_with(log_group_name='mygroup', fields=None)
 
         main(['-s', '2015-05-05 14:20:00', 'mygroup'])
         mock_reader.assert_called_with(
             log_group_name='mygroup',
+            fields=None,
             start_time=datetime(2015, 5, 5, 14, 20),
         )
 
         main(['--end-time', '2015-05-05 14:20:00', 'mygroup'])
         mock_reader.assert_called_with(
             log_group_name='mygroup',
+            fields=None,
             end_time=datetime(2015, 5, 5, 14, 20),
         )
 
@@ -84,23 +86,25 @@ class MainTestCase(TestCase):
         )
         mock_reader.assert_called_with(
             log_group_name='mygroup',
+            fields=None,
             start_time=datetime(2015, 5, 5),
         )
 
         main(['--region', 'us-west-1', 'mygroup'])
         mock_reader.assert_called_with(
             log_group_name='mygroup',
+            fields=None,
             region_name='us-west-1',
         )
 
         main(['--profile', 'my-profile', 'mygroup'])
         mock_reader.assert_called_with(
-            log_group_name='mygroup', profile_name='my-profile'
+            log_group_name='mygroup', fields=None, profile_name='my-profile'
         )
 
         main(['--filter-pattern', 'REJECT', 'mygroup'])
         mock_reader.assert_called_with(
-            log_group_name='mygroup', filter_pattern='REJECT'
+            log_group_name='mygroup', fields=None, filter_pattern='REJECT'
         )
 
     @patch('flowlogs_reader.__main__.FlowLogsReader', autospec=True)
@@ -225,7 +229,7 @@ class MainTestCase(TestCase):
         )
         session.return_value.client.assert_called_once_with('logs')
         mock_reader.assert_called_once_with(
-            log_group_name='mygroup', boto_client=mock_client
+            log_group_name='mygroup', fields=None, boto_client=mock_client
         )
 
     @patch('flowlogs_reader.__main__.S3FlowLogsReader', autospec=True)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -82,12 +82,15 @@ class MainTestCase(TestCase):
                 '--start-time',
                 '2015-05-05',
                 'mygroup',
+                '--thread-count',
+                '2',
             ]
         )
         mock_reader.assert_called_with(
             log_group_name='mygroup',
             fields=None,
             start_time=datetime(2015, 5, 5),
+            thread_count=2,
         )
 
         main(['--region', 'us-west-1', 'mygroup'])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -102,9 +102,19 @@ class MainTestCase(TestCase):
             log_group_name='mygroup', fields=None, profile_name='my-profile'
         )
 
-        main(['--filter-pattern', 'REJECT', 'mygroup'])
+        main(
+            [
+                '--filter-pattern',
+                'REJECT',
+                '--fields',
+                '${account-id} ${action}',
+                'mygroup',
+            ]
+        )
         mock_reader.assert_called_with(
-            log_group_name='mygroup', fields=None, filter_pattern='REJECT'
+            log_group_name='mygroup',
+            fields=('account-id', 'action'),
+            filter_pattern='REJECT',
         )
 
     @patch('flowlogs_reader.__main__.FlowLogsReader', autospec=True)


### PR DESCRIPTION
This PR is for version 3.0.0. The changes are:
* `boto3` client handling is now simplified. The `region_name`, `profile_name`, and `boto_client_kwargs` have been dropped. You can set the usual AWS environment variables to customize client creation, or pass in clients to the constructors yourself.
* Support for custom formats on CloudWatch logs has been added. By default they will be automatically detected using the `ec2` [DescribeFlowLogs](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeFlowLogs.html) API endpoint. You can also pass them in manually with the `fields` keyword in the library, or the `--fields` switch on the command line.
* The reader classes now keep track of the number of `bytes_processed`.