### PR TITLE
Version 3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,3 +236,6 @@ flow_log_reader = FlowLogsReader('flowlog_group')
 key_fields = ('srcaddr', 'dstaddr')
 records = list(aggregated_records(flow_log_reader, key_fields=key_fields))
 ```
+
+The number of bytes processed after iterating is available in the `bytes_processed` attribute.
+For `S3FlowLogsReader` instances there is also a `compressed_bytes_processed` attribute.

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -366,6 +366,8 @@ class S3FlowLogsReader(BaseReader):
         self.bucket, self.prefix = location_parts
         self.thread_count = thread_count
 
+        self.compressed_bytes_processed = 0
+
         self.include_accounts = (
             None if include_accounts is None else set(include_accounts)
         )
@@ -383,6 +385,7 @@ class S3FlowLogsReader(BaseReader):
             yield from reader
             with THREAD_LOCK:
                 self.bytes_processed += gz_f.tell()
+                self.compressed_bytes_processed += resp['ContentLength']
 
     def _get_keys(self, prefix):
         # S3 keys have a file name like:

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@
 
 [metadata]
 name = flowlogs_reader
-version = 3.0.0
+version = 3.1.0
 license = Apache
 url = https://github.com/obsrvbl/flowlogs-reader
 description = Reader for AWS VPC Flow Logs

--- a/tests/test_flowlogs_reader.py
+++ b/tests/test_flowlogs_reader.py
@@ -631,6 +631,9 @@ class S3FlowLogsReaderTestCase(TestCase):
         ]
         reader = self._test_iteration(V3_FILE, expected)
         self.assertEqual(reader.bytes_processed, len(V3_FILE.encode()))
+        self.assertEqual(
+            reader.compressed_bytes_processed, len(compress(V3_FILE.encode()))
+        )
 
     def test_serial_v4(self):
         expected = [
@@ -686,6 +689,9 @@ class S3FlowLogsReaderTestCase(TestCase):
         ]
         reader = self._test_iteration(V4_FILE, expected)
         self.assertEqual(reader.bytes_processed, len(V4_FILE.encode()))
+        self.assertEqual(
+            reader.compressed_bytes_processed, len(compress(V4_FILE.encode()))
+        )
 
     def test_serial_v5(self):
         expected = [
@@ -747,6 +753,9 @@ class S3FlowLogsReaderTestCase(TestCase):
         ]
         reader = self._test_iteration(V5_FILE, expected)
         self.assertEqual(reader.bytes_processed, len(V5_FILE.encode()))
+        self.assertEqual(
+            reader.compressed_bytes_processed, len(compress(V5_FILE.encode()))
+        )
 
     def test_threads(self):
         expected = [


### PR DESCRIPTION
This PR updates the package to version 3.1.0 and adds a new feature: for S3 readers, the number of compressed bytes are tracked. See #53 for the uncompressed bytes tracking, which is available for both S3 and CWL readers.