### PR TITLE
Skip TGW records

### DIFF
--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -108,6 +108,7 @@ class FlowRecord:
         if 'account_id' in event_data:
             if 'TransitGateway' in event_data['account_id']:
                 self.flowrecord_attr()
+                self.start, self.end = None, None
                 return
 
         if 'start' in event_data:
@@ -222,6 +223,7 @@ class FlowRecord:
         for key, value in zip(fields, data):
             event_data[key] = value
 
+        print(f'from_cwl_event: {event_data}')
         return cls(event_data)
 
 

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -18,7 +18,6 @@ from csv import DictReader as csv_dict_reader
 from datetime import datetime, timedelta
 from gzip import open as gz_open
 from os.path import basename
-from wsgiref import validate
 from parquet import DictReader as parquet_dict_reader
 from threading import Lock
 

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -103,8 +103,10 @@ class FlowRecord:
         # http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/flow-logs.html
 
         # 11665, transitgateway logs mixed with VPC logs causes ValueError
+        # https://docs.aws.amazon.com/vpc/latest/tgw/tgw-flow-logs.html#flow-log-records
+        # If logs mixed, will return blank flowrecord for TransitGateway
         if 'account_id' in event_data:
-            if event_data['account_id'] == 'TransitGateway':
+            if 'TransitGateway' in event_data['account_id']:
                 self.flowrecord_attr()
                 return
 

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -103,7 +103,7 @@ class FlowRecord:
         # In this case, we will set an invalid version number so that reader classes 
         # can properly skip that record. 
         # https://docs.aws.amazon.com/vpc/latest/tgw/tgw-flow-logs.html#flow-log-records
-        if event_data.get('account_id') in TGW_FAIL:
+        if event_data.get('account_id') in {'TransitGateway', 'TransitGatewayAttachment'}:
             self.flowrecord_attr()
             self.version = SKIP_RECORD
             self.start, self.end = None, None

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -101,7 +101,7 @@ class FlowRecord:
         # millisecond-based timestamps.
         # http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/flow-logs.html
 
-        if not self.validate_event_data(event_data):
+        if not self.validate_not_transitgateway(event_data):
             return {}
 
         if 'start' in event_data:
@@ -199,8 +199,11 @@ class FlowRecord:
         return ' '.join(ret)
 
     # validate data is NOT transit gateway, issue # 11665
-    def validate_event_data(self):
-        pass
+    def validate_not_transitgateway(self, event_data):
+        if event_data['account_id'] == 'TransitGateway':
+            return False
+        else:
+            return True
 
     @classmethod
     def from_cwl_event(cls, cwl_event, fields=DEFAULT_FIELDS):

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -101,7 +101,8 @@ class FlowRecord:
         # millisecond-based timestamps.
         # http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/flow-logs.html
 
-        if not self.validate_not_transitgateway(event_data):
+        # validate data is NOT transit gateway, issue # 11665
+        if event_data['account_id'] == 'TransitGateway':
             return None
 
         if 'start' in event_data:
@@ -197,13 +198,6 @@ class FlowRecord:
             ret.append(transform(getattr(self, attr)))
 
         return ' '.join(ret)
-
-    # validate data is NOT transit gateway, issue # 11665
-    def validate_not_transitgateway(self, event_data):
-        if event_data['account_id'] == 'TransitGateway':
-            return False
-        else:
-            return True
 
     @classmethod
     def from_cwl_event(cls, cwl_event, fields=DEFAULT_FIELDS):

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -360,15 +360,22 @@ class FlowLogsReader(BaseReader):
                 func = lambda x: list(self._read_streams(x))
                 for events in executor.map(func, all_streams):
                     for event in events:
-                        yield FlowRecord.from_cwl_event(event, self.fields)
+                        formatted_event = FlowRecord.from_cwl_event(
+                            event, self.fields
+                        )
+                        if FlowRecord.validate_not_transitgateway(
+                            formatted_event
+                        ):
+                            yield formatted_event
+                        else:
+                            continue
         else:
             for event in self._read_streams():
-                validated_event = FlowRecord.from_cwl_event(event, self.fields)
-                if FlowRecord.validate_not_transitgateway(validated_event):
-                    yield validated_event
+                formatted_event = FlowRecord.from_cwl_event(event, self.fields)
+                if FlowRecord.validate_not_transitgateway(formatted_event):
+                    yield formatted_event
                 else:
-                    return
-                    yield
+                    continue
 
 
 class S3FlowLogsReader(BaseReader):
@@ -507,5 +514,4 @@ class S3FlowLogsReader(BaseReader):
             if FlowRecord.validate_not_transitgateway(event_data):
                 yield FlowRecord(event_data)
             else:
-                return
-                yeild
+                continue

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -110,10 +110,10 @@ class FlowRecord:
             if event_data['account_id'] in TGW_FAIL:
                 self.flowrecord_attr()
                 self.start, self.end = None, None
-                self.is_transitgateway = True
+                self.is_transit_gateway = True
                 return
 
-        self.is_transitgateway = False
+        self.is_transit_gateway = False
         if 'start' in event_data:
             start = int(event_data['start'])
             if start > EPOCH_32_MAX:
@@ -376,12 +376,12 @@ class FlowLogsReader(BaseReader):
                 for events in executor.map(func, all_streams):
                     for event in events:
                         flow = FlowRecord.from_cwl_event(event, self.fields)
-                        if not flow.is_transitgateway:
+                        if not flow.is_transit_gateway:
                             yield flow
         else:
             for event in self._read_streams():
                 flow = FlowRecord.from_cwl_event(event, self.fields)
-                if not flow.is_transitgateway:
+                if not flow.is_transit_gateway:
                     yield flow
 
 
@@ -519,5 +519,5 @@ class S3FlowLogsReader(BaseReader):
     def _reader(self):
         for event_data in self._read_streams():
             flow = FlowRecord(event_data)
-            if not flow.is_transitgateway:
+            if not flow.is_transit_gateway:
                 yield flow

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -104,10 +104,10 @@ class FlowRecord:
         # millisecond-based timestamps.
         # http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/flow-logs.html
 
-        # 11665, transitgateway logs mixed with VPC logs causes ValueError
+        # AWS allows VPCFlowLogs and TransitGateway logs to exist in the same file. 
+        # In this case, we will set an invalid version number so that reader classes 
+        # can properly skip that record. 
         # https://docs.aws.amazon.com/vpc/latest/tgw/tgw-flow-logs.html#flow-log-records
-        # If logs mixed, will return blank flowrecord for TransitGateway
-
         if event_data.get('account_id') in TGW_FAIL:
             self.flowrecord_attr()
             self.version = SKIP_RECORD

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -101,6 +101,9 @@ class FlowRecord:
         # millisecond-based timestamps.
         # http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/flow-logs.html
 
+        if not self.validate_event_data(event_data):
+            return {}
+
         if 'start' in event_data:
             start = int(event_data['start'])
             if start > EPOCH_32_MAX:

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -108,7 +108,7 @@ class FlowRecord:
         # https://docs.aws.amazon.com/vpc/latest/tgw/tgw-flow-logs.html#flow-log-records
         # If logs mixed, will return blank flowrecord for TransitGateway
         if 'account_id' in event_data:
-            if event_data['account_id'] in TGW_FAIL :
+            if event_data['account_id'] in TGW_FAIL:
                 self.flowrecord_attr()
                 self.version = SKIP_RECORD
                 self.start, self.end = None, None

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -100,6 +100,7 @@ class FlowRecord:
         # Contra the docs, the start and end fields can contain
         # millisecond-based timestamps.
         # http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/flow-logs.html
+
         if 'start' in event_data:
             start = int(event_data['start'])
             if start > EPOCH_32_MAX:
@@ -193,6 +194,10 @@ class FlowRecord:
             ret.append(transform(getattr(self, attr)))
 
         return ' '.join(ret)
+
+    # validate data is NOT transit gateway, issue # 11665
+    def validate_event_data(self):
+        pass
 
     @classmethod
     def from_cwl_event(cls, cwl_event, fields=DEFAULT_FIELDS):

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -204,10 +204,7 @@ class FlowRecord:
         for key, value in zip(fields, data):
             event_data[key] = value
 
-        if FlowRecord.validate_not_transitgateway(event_data):
-            return cls(event_data)
-        else:
-            return None
+        return cls(event_data)
 
     # 11665, transitgateway logs mixed with VPC logs causes ValueError
     @classmethod
@@ -369,6 +366,9 @@ class FlowLogsReader(BaseReader):
                 validated_event = FlowRecord.from_cwl_event(event, self.fields)
                 if FlowRecord.validate_not_transitgateway(validated_event):
                     yield validated_event
+                else:
+                    return
+                    yield
 
 
 class S3FlowLogsReader(BaseReader):
@@ -506,3 +506,6 @@ class S3FlowLogsReader(BaseReader):
         for event_data in self._read_streams():
             if FlowRecord.validate_not_transitgateway(event_data):
                 yield FlowRecord(event_data)
+            else:
+                return
+                yeild

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -223,7 +223,6 @@ class FlowRecord:
         for key, value in zip(fields, data):
             event_data[key] = value
 
-        print(f'from_cwl_event: {event_data}')
         return cls(event_data)
 
 

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -371,6 +371,7 @@ class FlowLogsReader(BaseReader):
                 if FlowRecord.validate(validated_event):
                     yield validated_event
 
+
 class S3FlowLogsReader(BaseReader):
     def __init__(
         self,

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -57,6 +57,7 @@ NODATA = 'NODATA'
 
 THREAD_LOCK = Lock()
 
+TGW_FAIL = ['TransitGateway', 'TransitGatewayAttachment']
 
 class FlowRecord:
     """
@@ -106,7 +107,7 @@ class FlowRecord:
         # https://docs.aws.amazon.com/vpc/latest/tgw/tgw-flow-logs.html#flow-log-records
         # If logs mixed, will return blank flowrecord for TransitGateway
         if 'account_id' in event_data:
-            if 'TransitGateway' in event_data['account_id']:
+            if event_data['account_id'] in TGW_FAIL:
                 self.flowrecord_attr()
                 self.start, self.end = None, None
                 return

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -100,10 +100,6 @@ class FlowRecord:
     ]
 
     def __init__(self, event_data, EPOCH_32_MAX=2147483647):
-        # Contra the docs, the start and end fields can contain
-        # millisecond-based timestamps.
-        # http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/flow-logs.html
-
         # AWS allows VPCFlowLogs and TransitGateway logs to exist in the same file. 
         # In this case, we will set an invalid version number so that reader classes 
         # can properly skip that record. 
@@ -114,6 +110,9 @@ class FlowRecord:
             self.start, self.end = None, None
             return
 
+        # Contra the docs, the start and end fields can contain
+        # millisecond-based timestamps.
+        # http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/flow-logs.html
         if 'start' in event_data:
             start = int(event_data['start'])
             if start > EPOCH_32_MAX:

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -209,13 +209,12 @@ class FlowRecord:
         else:
             return None
 
-    
+    # 11665, transitgateway logs mixed with VPC logs causes ValueError
     @classmethod
     def validate_not_transitgateway(cls, event):
         if event['account-id'] == 'TransitGateway':
             return False
         return True
-    
 
 
 class BaseReader:

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -209,8 +209,9 @@ class FlowRecord:
     # 11665, transitgateway logs mixed with VPC logs causes ValueError
     @classmethod
     def validate_not_transitgateway(cls, event):
-        if event['account_id'] == 'TransitGateway':
-            return False
+        if 'account_id' in event:
+            if event['account_id'] == 'TransitGateway':
+                return False
         return True
 
 

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -107,12 +107,12 @@ class FlowRecord:
         # 11665, transitgateway logs mixed with VPC logs causes ValueError
         # https://docs.aws.amazon.com/vpc/latest/tgw/tgw-flow-logs.html#flow-log-records
         # If logs mixed, will return blank flowrecord for TransitGateway
-        if 'account_id' in event_data:
-            if event_data['account_id'] in TGW_FAIL:
-                self.flowrecord_attr()
-                self.version = SKIP_RECORD
-                self.start, self.end = None, None
-                return
+
+        if event_data.get('account_id') in TGW_FAIL:
+            self.flowrecord_attr()
+            self.version = SKIP_RECORD
+            self.start, self.end = None, None
+            return
 
         if 'start' in event_data:
             start = int(event_data['start'])

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -368,7 +368,7 @@ class FlowLogsReader(BaseReader):
         else:
             for event in self._read_streams():
                 validated_event = FlowRecord.from_cwl_event(event, self.fields)
-                if FlowRecord.validate(validated_event):
+                if FlowRecord.validate_not_transitgateway(validated_event):
                     yield validated_event
 
 

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -102,7 +102,7 @@ class FlowRecord:
         # http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/flow-logs.html
 
         if not self.validate_not_transitgateway(event_data):
-            return {}
+            return None
 
         if 'start' in event_data:
             start = int(event_data['start'])

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -212,7 +212,7 @@ class FlowRecord:
     # 11665, transitgateway logs mixed with VPC logs causes ValueError
     @classmethod
     def validate_not_transitgateway(cls, event):
-        if event['account-id'] == 'TransitGateway':
+        if event['account_id'] == 'TransitGateway':
             return False
         return True
 

--- a/tests/test_flowlogs_reader.py
+++ b/tests/test_flowlogs_reader.py
@@ -58,6 +58,10 @@ V2_RECORDS = [
         '2 123456789010 eni-4b118871 - - - - - - - '
         '1431280876 1431280934 - SKIPDATA'
     ),
+    (
+        '6 TransitGateway eni-102010cd 192.0.2.1 198.51.100.1 '
+        '49152 443 6 20 1680 1439387263 1439387266 REJECT OK'
+    ),
 ]
 
 V3_FILE = (
@@ -101,29 +105,6 @@ V5_FILE = (
     'subnet-0123456789abcdef 7 7 IPv4 5 vpc-04456ab739938ee3f\n'
 )
 
-V2_RECORDS_MIXED_TGW = [
-    (
-        '2 123456789010 eni-102010ab 198.51.100.1 192.0.2.1 '
-        '443 49152 6 10 840 1439387263 1439387264 ACCEPT OK'
-    ),
-    (
-        '2 123456789010 eni-102010ab 192.0.2.1 198.51.100.1 '
-        '49152 443 6 20 1680 1439387264 1439387265 ACCEPT OK'
-    ),
-    (
-        '6 TransitGateway eni-102010cd 192.0.2.1 198.51.100.1 '
-        '49152 443 6 20 1680 1439387263 1439387266 REJECT OK'
-    ),
-    (
-        '2 123456789010 eni-1a2b3c4d - - - - - - - '
-        '1431280876 1431280934 - NODATA'
-    ),
-    (
-        '2 123456789010 eni-4b118871 - - - - - - - '
-        '1431280876 1431280934 - SKIPDATA'
-    ),
-]
-
 PARQUET_FILE = 'tests/data/flows.parquet'
 
 
@@ -150,7 +131,7 @@ class FlowRecordTestCase(TestCase):
         self.assertEqual(actual, expected)
 
     def test_parse_tgw(self):
-        flow_record = FlowRecord.from_cwl_event({'message': V2_RECORDS_MIXED_TGW[2]})
+        flow_record = FlowRecord.from_cwl_event({'message': V2_RECORDS[5]})
         actual = flow_record.to_dict()
         expected = {'version': SKIP_RECORD}
         self.assertEqual(actual, expected)
@@ -339,6 +320,7 @@ class FlowLogsReaderTestCase(TestCase):
                     {'logStreamName': 'log_0', 'message': V2_RECORDS[2]},
                     {'logStreamName': 'log_1', 'message': V2_RECORDS[3]},
                     {'logStreamName': 'log_2', 'message': V2_RECORDS[4]},
+                    {'logStreamName': 'log_2', 'message': V2_RECORDS[5]},
                 ],
             },
         ]
@@ -348,7 +330,7 @@ class FlowLogsReaderTestCase(TestCase):
         # Calling list on the instance causes it to iterate through all records
         actual = [next(self.inst)] + list(self.inst)
         expected = [
-            FlowRecord.from_cwl_event({'message': x}) for x in V2_RECORDS
+            FlowRecord.from_cwl_event({'message': x}) for x in V2_RECORDS[:-1]
         ]
         self.assertEqual(actual, expected)
 

--- a/tests/test_flowlogs_reader.py
+++ b/tests/test_flowlogs_reader.py
@@ -32,10 +32,9 @@ from flowlogs_reader import (
 from flowlogs_reader.flowlogs_reader import (
     DUPLICATE_NEXT_TOKEN_MESSAGE,
     LAST_EVENT_DELAY_MSEC,
+    SKIP_RECORD
 )
 
-
-SKIP_RECORD = -1
 
 V2_RECORDS = [
     (

--- a/tests/test_flowlogs_reader.py
+++ b/tests/test_flowlogs_reader.py
@@ -150,7 +150,7 @@ class FlowRecordTestCase(TestCase):
     def test_parse_tgw(self):
         flow_record = FlowRecord.from_cwl_event({'message': V2_RECORDS_MIXED_TGW[2]})
         actual = flow_record.to_dict()
-        expected = {}
+        expected = {'account_id': 'TGW_DROP'}
         self.assertEqual(actual, expected)
 
     def test_eq(self):

--- a/tests/test_flowlogs_reader.py
+++ b/tests/test_flowlogs_reader.py
@@ -790,69 +790,6 @@ class S3FlowLogsReaderTestCase(TestCase):
             reader.compressed_bytes_processed, len(compress(V5_FILE.encode()))
         )
 
-    def test_serial_v5_tgw(self):
-        expected = [
-            {
-                'account_id': '999999999999',
-                'action': 'ACCEPT',
-                'az_id': 'use2-az2',
-                'bytes': 4895,
-                'dstaddr': '192.0.2.156',
-                'dstport': 50318,
-                'end': datetime(2021, 3, 4, 14, 1, 51),
-                'flow_direction': 'ingress',
-                'instance_id': 'i-00123456789abcdef',
-                'interface_id': 'eni-00123456789abcdef',
-                'log_status': 'OK',
-                'packets': 15,
-                'pkt_dstaddr': '192.0.2.156',
-                'pkt_src_aws_service': 'S3',
-                'pkt_srcaddr': '198.51.100.6',
-                'protocol': 6,
-                'region': 'us-east-2',
-                'srcaddr': '198.51.100.7',
-                'srcport': 443,
-                'start': datetime(2021, 3, 4, 14, 1, 33),
-                'subnet_id': 'subnet-0123456789abcdef',
-                'tcp_flags': 19,
-                'type': 'IPv4',
-                'version': 5,
-                'vpc_id': 'vpc-04456ab739938ee3f',
-            },
-            {
-                'account_id': '999999999999',
-                'action': 'ACCEPT',
-                'az_id': 'use2-az2',
-                'bytes': 3015,
-                'dstaddr': '198.51.100.6',
-                'dstport': 443,
-                'end': datetime(2021, 3, 4, 14, 1, 51),
-                'flow_direction': 'egress',
-                'instance_id': 'i-00123456789abcdef',
-                'interface_id': 'eni-00123456789abcdef',
-                'log_status': 'OK',
-                'packets': 16,
-                'pkt_dst_aws_service': 'S3',
-                'pkt_dstaddr': '198.51.100.7',
-                'pkt_srcaddr': '192.0.2.156',
-                'protocol': 6,
-                'region': 'us-east-2',
-                'srcaddr': '192.0.2.156',
-                'srcport': 50318,
-                'start': datetime(2021, 3, 4, 14, 1, 33),
-                'subnet_id': 'subnet-0123456789abcdef',
-                'tcp_flags': 7,
-                'traffic_path': 7,
-                'type': 'IPv4',
-                'version': 5,
-                'vpc_id': 'vpc-04456ab739938ee3f',
-            },
-        ]
-        reader = self._test_iteration(V5_FILE, expected)
-        self.assertEqual(reader.bytes_processed, len(V5_FILE.encode()))
-        self.assertEqual(
-            reader.compressed_bytes_processed, len(compress(V5_FILE.encode()))
-        )
 
     def _test_parquet_reader(self, data, expected):
         boto_client = boto3.client('s3')

--- a/tests/test_flowlogs_reader.py
+++ b/tests/test_flowlogs_reader.py
@@ -150,22 +150,7 @@ class FlowRecordTestCase(TestCase):
     def test_parse_tgw(self):
         flow_record = FlowRecord.from_cwl_event({'message': V2_RECORDS_MIXED_TGW[2]})
         actual = flow_record.to_dict()
-        expected = {
-            'account_id': None,
-            'action': None,
-            'bytes': None,
-            'dstaddr': None,
-            'dstport': None,
-            'end': None,
-            'interface_id': None,
-            'log_status': None,
-            'packets': None,
-            'protocol': None,
-            'srcaddr': None,
-            'srcport': None,
-            'start': None,
-            'version': None,
-        }
+        expected = {}
         self.assertEqual(actual, expected)
 
     def test_eq(self):

--- a/tests/test_flowlogs_reader.py
+++ b/tests/test_flowlogs_reader.py
@@ -790,7 +790,6 @@ class S3FlowLogsReaderTestCase(TestCase):
             reader.compressed_bytes_processed, len(compress(V5_FILE.encode()))
         )
 
-
     def _test_parquet_reader(self, data, expected):
         boto_client = boto3.client('s3')
         with Stubber(boto_client) as stubbed_client:

--- a/tests/test_flowlogs_reader.py
+++ b/tests/test_flowlogs_reader.py
@@ -35,6 +35,8 @@ from flowlogs_reader.flowlogs_reader import (
 )
 
 
+SKIP_RECORD = -1
+
 V2_RECORDS = [
     (
         '2 123456789010 eni-102010ab 198.51.100.1 192.0.2.1 '
@@ -150,7 +152,7 @@ class FlowRecordTestCase(TestCase):
     def test_parse_tgw(self):
         flow_record = FlowRecord.from_cwl_event({'message': V2_RECORDS_MIXED_TGW[2]})
         actual = flow_record.to_dict()
-        expected = {'account_id': 'TGW_DROP'}
+        expected = {'version': SKIP_RECORD}
         self.assertEqual(actual, expected)
 
     def test_eq(self):


### PR DESCRIPTION
Ref: https://github.com/obsrvbl/devops/issues/11665

**Problem-statement:** The above issue states that the code handles vpc flow data with [default](https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs.html) format but does not take in consideration if [transit-gateway](https://docs.aws.amazon.com/vpc/latest/tgw/tgw-flow-logs.html#flow-logs-default) is enabled. So when input data contains mixed records including transitgateway records, it errors out on fields contains tgw-logs.
Since transit-gateway logs are not supported in `flowlogs-reader`, maybe we can skip those fields instead of parsing them.

This PR intends to safely ignore all fields that contain Transit Gateway records.