### PR TITLE
New direction for handling failed flowrecords

### DIFF
--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -354,16 +354,16 @@ class FlowLogsReader(BaseReader):
                         try: 
                             flow = FlowRecord.from_cwl_event(event, self.fields)
                             yield flow
-                        except ValueError as ve:
-                            yield ve
+                        except ValueError as err:
+                            yield err
                         
         else:
             for event in self._read_streams():
                 try: 
                     flow = FlowRecord.from_cwl_event(event, self.fields)
                     yield flow
-                except ValueError as ve:
-                    yield ve
+                except ValueError as err:
+                    yield err
 
 
 
@@ -503,6 +503,6 @@ class S3FlowLogsReader(BaseReader):
             try: 
                 flow = FlowRecord(event_data)
                 yield flow
-            except ValueError as ve:
-                yield ve
+            except ValueError as err:
+                yield err
 

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -357,18 +357,18 @@ class FlowLogsReader(BaseReader):
                         try: 
                             flow = FlowRecord.from_cwl_event(event, self.fields)
                             yield flow
-                        except Exception as err:
+                        except Exception:
                             self.skipped_records += 1
-                            yield err
+                            continue
                         
         else:
             for event in self._read_streams():
                 try: 
                     flow = FlowRecord.from_cwl_event(event, self.fields)
                     yield flow
-                except Exception as err:
+                except Exception:
                     self.skipped_records += 1
-                    yield err
+                    continue
 
 
 
@@ -508,7 +508,7 @@ class S3FlowLogsReader(BaseReader):
             try: 
                 flow = FlowRecord(event_data)
                 yield flow
-            except Exception as err:
+            except Exception:
                 self.skipped_records += 1
-                yield err
+                continue
 

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -357,8 +357,7 @@ class FlowLogsReader(BaseReader):
                 for events in executor.map(func, all_streams):
                     for event in events:
                         try: 
-                            flow = FlowRecord.from_cwl_event(event, self.fields)
-                            yield flow
+                            yield FlowRecord.from_cwl_event(event, self.fields)
                         except Exception:
                             self.skipped_records += 1
                             if self.raise_on_error:
@@ -366,8 +365,7 @@ class FlowLogsReader(BaseReader):
         else:
             for event in self._read_streams():
                 try: 
-                    flow = FlowRecord.from_cwl_event(event, self.fields)
-                    yield flow
+                    yield FlowRecord.from_cwl_event(event, self.fields)
                 except Exception:
                     self.skipped_records += 1
                     if self.raise_on_error:
@@ -509,8 +507,7 @@ class S3FlowLogsReader(BaseReader):
     def _reader(self):
         for event_data in self._read_streams():
             try: 
-                flow = FlowRecord(event_data)
-                yield flow
+                yield FlowRecord(event_data)
             except Exception:
                 self.skipped_records += 1
                 if self.raise_on_error:

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -354,7 +354,7 @@ class FlowLogsReader(BaseReader):
                         try: 
                             flow = FlowRecord.from_cwl_event(event, self.fields)
                             yield flow
-                        except ValueError as ve:
+                        except ValueError:
                             print('[ERROR] FlowRecord line ValueError, continuing...')
                             continue
                         
@@ -363,7 +363,7 @@ class FlowLogsReader(BaseReader):
                 try: 
                     flow = FlowRecord.from_cwl_event(event, self.fields)
                     yield flow
-                except ValueError as ve:
+                except ValueError:
                     print('[ERROR] FlowRecord line ValueError, continuing...')
                     continue
 
@@ -504,6 +504,6 @@ class S3FlowLogsReader(BaseReader):
             try: 
                 flow = FlowRecord(event_data)
                 yield flow
-            except ValueError as ve:
+            except ValueError:
                 print('[ERROR] FlowRecord line ValueError, continuing...')
                 continue

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -351,10 +351,21 @@ class FlowLogsReader(BaseReader):
                 func = lambda x: list(self._read_streams(x))
                 for events in executor.map(func, all_streams):
                     for event in events:
-                        yield FlowRecord.from_cwl_event(event, self.fields)
+                        try: 
+                            flow = FlowRecord.from_cwl_event(event, self.fields)
+                            yield flow
+                        except ValueError as ve:
+                            print('[ERROR] FlowRecord line ValueError, continuing...')
+                            continue
+                        
         else:
             for event in self._read_streams():
-                yield FlowRecord.from_cwl_event(event, self.fields)
+                try: 
+                    flow = FlowRecord.from_cwl_event(event, self.fields)
+                    yield flow
+                except ValueError as ve:
+                    print('[ERROR] FlowRecord line ValueError, continuing...')
+                    continue
 
 
 class S3FlowLogsReader(BaseReader):
@@ -490,4 +501,9 @@ class S3FlowLogsReader(BaseReader):
 
     def _reader(self):
         for event_data in self._read_streams():
-            yield FlowRecord(event_data)
+            try: 
+                flow = FlowRecord(event_data)
+                yield flow
+            except ValueError as ve:
+                print('[ERROR] FlowRecord line ValueError, continuing...')
+                continue

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -213,6 +213,7 @@ class BaseReader:
         start_time=None,
         end_time=None,
         boto_client=None,
+        raise_on_error=False
     ):
         self.region_name = region_name
         if boto_client is not None:
@@ -230,6 +231,7 @@ class BaseReader:
         self.iterator = self._reader()
 
         self.skipped_records = 0
+        self.raise_on_error = raise_on_error
 
     def __iter__(self):
         return self
@@ -359,8 +361,8 @@ class FlowLogsReader(BaseReader):
                             yield flow
                         except Exception:
                             self.skipped_records += 1
-                            continue
-                        
+                            if self.raise_on_error:
+                                raise  
         else:
             for event in self._read_streams():
                 try: 
@@ -368,7 +370,8 @@ class FlowLogsReader(BaseReader):
                     yield flow
                 except Exception:
                     self.skipped_records += 1
-                    continue
+                    if self.raise_on_error:
+                        raise
 
 
 
@@ -510,5 +513,6 @@ class S3FlowLogsReader(BaseReader):
                 yield flow
             except Exception:
                 self.skipped_records += 1
-                continue
+                if self.raise_on_error:
+                    raise
 

--- a/flowlogs_reader/flowlogs_reader.py
+++ b/flowlogs_reader/flowlogs_reader.py
@@ -354,18 +354,17 @@ class FlowLogsReader(BaseReader):
                         try: 
                             flow = FlowRecord.from_cwl_event(event, self.fields)
                             yield flow
-                        except ValueError:
-                            print('[ERROR] FlowRecord line ValueError, continuing...')
-                            continue
+                        except ValueError as ve:
+                            yield ve
                         
         else:
             for event in self._read_streams():
                 try: 
                     flow = FlowRecord.from_cwl_event(event, self.fields)
                     yield flow
-                except ValueError:
-                    print('[ERROR] FlowRecord line ValueError, continuing...')
-                    continue
+                except ValueError as ve:
+                    yield ve
+
 
 
 class S3FlowLogsReader(BaseReader):
@@ -504,6 +503,6 @@ class S3FlowLogsReader(BaseReader):
             try: 
                 flow = FlowRecord(event_data)
                 yield flow
-            except ValueError:
-                print('[ERROR] FlowRecord line ValueError, continuing...')
-                continue
+            except ValueError as ve:
+                yield ve
+


### PR DESCRIPTION
The idea behind this is to simply try catch the init of FlowRecord, and if an exception is caught, increment the "skipped_records" field of the basereader class. This value can then be checked and logged in the consuming class for further investigation if warranted. Also added an override during class init to raise the exception instead.




